### PR TITLE
Add post-v0.1 task plans (P5-P8)

### DIFF
--- a/docs/tasks/P5-001-fix-sha-extraction.md
+++ b/docs/tasks/P5-001-fix-sha-extraction.md
@@ -1,0 +1,48 @@
+# P5-001: Fix SHA Extraction in Executor
+
+**Phase:** 5 — Quick Wins & Code Quality
+**Priority:** High impact, low effort
+**Affects:** `src/jetsam/core/executor.py`
+
+## Problem
+
+The `_exec_commit` function (executor.py:171-184) extracts the commit SHA by scanning
+`git commit` output lines, looking for lines starting with `[` and guessing which
+space-separated token looks like a hex string. This is fragile across git versions,
+locales, and output format changes.
+
+```python
+# Current (fragile)
+for line in result.stdout.splitlines():
+    if line.startswith("["):
+        parts = line.split()
+        for p in parts:
+            if len(p) >= 7 and p.rstrip("]").replace("-", "").isalnum():
+                sha = p.rstrip("]")
+                break
+```
+
+## Solution
+
+After a successful commit, run `git rev-parse --short HEAD` to reliably get the SHA:
+
+```python
+if result.ok:
+    sha_result = run_git_sync(["rev-parse", "--short", "HEAD"], cwd=cwd)
+    sha = sha_result.stdout.strip() if sha_result.ok else ""
+    return StepResult(step="commit", ok=True, details={"sha": sha, "message": message})
+```
+
+This adds one subprocess call per commit but is completely reliable regardless of
+git version or locale.
+
+## Acceptance Criteria
+
+- [ ] `_exec_commit` uses `git rev-parse --short HEAD` for SHA extraction
+- [ ] Existing tests still pass
+- [ ] No change to `StepResult` shape (sha field still present)
+
+## Estimated Scope
+
+~5 lines changed in `executor.py`. Possibly update test assertions if they validate
+specific SHA values.

--- a/docs/tasks/P5-002-consolidate-platform-error.md
+++ b/docs/tasks/P5-002-consolidate-platform-error.md
@@ -1,0 +1,41 @@
+# P5-002: Consolidate PlatformError into Base Module
+
+**Phase:** 5 — Quick Wins & Code Quality
+**Priority:** High impact, low effort
+**Affects:** `src/jetsam/platforms/base.py`, `github.py`, `gitlab.py`
+
+## Problem
+
+`PlatformError` is defined independently at the bottom of both `github.py` (line 263)
+and `gitlab.py` (line 279) as separate, unrelated exception classes. If a caller catches
+one, it won't catch the other. If executor code catches `PlatformError` from a generic
+platform reference, it depends on which module was imported.
+
+## Solution
+
+1. Move `PlatformError` to `platforms/base.py` alongside the abstract `Platform` class
+2. Import it from `base.py` in both `github.py` and `gitlab.py`
+3. Remove the duplicate definitions
+
+```python
+# base.py (add at bottom)
+class PlatformError(Exception):
+    """Raised when a platform operation fails."""
+```
+
+```python
+# github.py / gitlab.py
+from jetsam.platforms.base import CheckResult, IssueDetails, Platform, PRDetails, PlatformError
+```
+
+## Acceptance Criteria
+
+- [ ] Single `PlatformError` definition in `base.py`
+- [ ] Both adapters import from `base.py`
+- [ ] `from jetsam.platforms.base import PlatformError` works for callers
+- [ ] Re-export from `platforms/__init__.py` for convenience
+- [ ] All existing tests pass
+
+## Estimated Scope
+
+~10 lines changed across 3 files.

--- a/docs/tasks/P5-003-add-py-typed-marker.md
+++ b/docs/tasks/P5-003-add-py-typed-marker.md
@@ -1,0 +1,32 @@
+# P5-003: Add py.typed Marker
+
+**Phase:** 5 — Quick Wins & Code Quality
+**Priority:** High impact, low effort
+**Affects:** `src/jetsam/`
+
+## Problem
+
+The package uses strict mypy and has comprehensive type annotations, but doesn't ship
+a `py.typed` marker file (PEP 561). Downstream consumers who import jetsam modules
+can't benefit from the type annotations because mypy/pyright won't recognize the
+package as typed.
+
+## Solution
+
+Create an empty `py.typed` file in the package root:
+
+```bash
+touch src/jetsam/py.typed
+```
+
+Verify it's included in the wheel by checking `hatch build` output.
+
+## Acceptance Criteria
+
+- [ ] `src/jetsam/py.typed` exists (empty file)
+- [ ] File is included in built wheel
+- [ ] mypy continues to pass
+
+## Estimated Scope
+
+1 new file.

--- a/docs/tasks/P5-004-add-test-coverage.md
+++ b/docs/tasks/P5-004-add-test-coverage.md
@@ -1,0 +1,55 @@
+# P5-004: Add Test Coverage Measurement
+
+**Phase:** 5 — Quick Wins & Code Quality
+**Priority:** High impact, low effort
+**Affects:** `pyproject.toml`, CI configuration
+
+## Problem
+
+There are 269 tests but no coverage measurement. Without quantitative coverage data,
+it's impossible to know which code paths are untested. The project uses `pytest` but
+doesn't include `pytest-cov`.
+
+## Solution
+
+1. Add `pytest-cov` to dev dependencies in `pyproject.toml`
+2. Configure coverage in `pyproject.toml`
+3. Update CI to report coverage
+
+```toml
+# pyproject.toml additions
+
+[project.optional-dependencies]
+dev = [
+    # ... existing ...
+    "pytest-cov>=4.0",
+]
+
+[tool.coverage.run]
+source = ["jetsam"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+skip_empty = true
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.",
+    "if TYPE_CHECKING:",
+]
+```
+
+3. Update the test command in `.lq/commands.toml` to include coverage
+4. Consider adding a coverage threshold once baseline is established
+
+## Acceptance Criteria
+
+- [ ] `pytest-cov` in dev dependencies
+- [ ] `[tool.coverage.*]` configured in `pyproject.toml`
+- [ ] `pytest --cov=jetsam --cov-report=term-missing` runs successfully
+- [ ] Coverage baseline documented (expected ~80%+ given current test suite)
+- [ ] CI reports coverage (optional: enforce minimum threshold)
+
+## Estimated Scope
+
+Config changes in `pyproject.toml` and `.lq/commands.toml`. No source code changes.

--- a/docs/tasks/P5-005-trigger-plan-cleanup.md
+++ b/docs/tasks/P5-005-trigger-plan-cleanup.md
@@ -1,0 +1,44 @@
+# P5-005: Trigger Plan Cleanup on Expired Plans
+
+**Phase:** 5 — Quick Wins & Code Quality
+**Priority:** Medium impact, low effort
+**Affects:** `src/jetsam/core/plans.py`, `src/jetsam/mcp/tools.py`
+
+## Problem
+
+`PlanStore.cleanup_expired()` exists but is never called. Expired plan files accumulate
+in `.jetsam/plans/` indefinitely. While each file is small (~1KB), a busy agent
+session could create dozens of plans that never get cleaned up.
+
+## Solution
+
+Call `cleanup_expired()` opportunistically in one or both of these locations:
+
+1. **In `_get_store()`** (tools.py) — cleanup runs once when the store is first
+   initialized for a session
+2. **In `plan_tidy`** — since `tidy` is already about cleanup, it should also
+   clean expired plans
+
+Option 1 is the minimal fix. Option 2 adds explicit user-facing cleanup.
+
+```python
+# tools.py - _get_store()
+def _get_store() -> PlanStore:
+    global _plan_store
+    if _plan_store is None:
+        state = build_state()
+        _plan_store = PlanStore(state.repo_root)
+        _plan_store.cleanup_expired()  # Clean up on first access
+    return _plan_store
+```
+
+## Acceptance Criteria
+
+- [ ] Expired plans are cleaned up automatically
+- [ ] `tidy` verb cleans expired plans in addition to branches
+- [ ] Add test: create expired plan file, verify cleanup removes it
+- [ ] No performance impact on normal operations
+
+## Estimated Scope
+
+~5 lines in `tools.py`, ~3 lines in `tidy` planner/executor, 1 new test.

--- a/docs/tasks/P6-001-wire-config-into-planners.md
+++ b/docs/tasks/P6-001-wire-config-into-planners.md
@@ -1,0 +1,95 @@
+# P6-001: Wire Config into Planners
+
+**Phase:** 6 — Config & Standardization
+**Priority:** High impact, moderate effort
+**Affects:** `src/jetsam/core/planner.py`, `src/jetsam/mcp/tools.py`, CLI verbs
+
+## Problem
+
+`JetsamConfig` defines 9 configuration options (platform, merge_strategy, auto_push,
+ship_default, pr_draft, branch_prefix, delete_on_merge, worktree, commit_message),
+but `load_config()` is never called by any planner function or MCP tool. All planners
+use hardcoded defaults.
+
+This is the single largest gap between the product spec and the implementation.
+
+### Specific gaps:
+
+| Config Option | Expected Behavior | Current Behavior |
+|---|---|---|
+| `auto_push` | `save` generates push step when true | Always omits push |
+| `pr_draft` | `ship`/`pr` creates draft PR when true | Always non-draft |
+| `ship_default` | `ship` defaults to PR or merge | Always defaults to PR |
+| `merge_strategy` | `finish`/`ship --merge` uses configured strategy | Always "squash" |
+| `branch_prefix` | `start` prefixes branch names | Only uses explicit prefix |
+| `delete_on_merge` | `finish` respects config | Always deletes |
+| `commit_message` | `save`/`ship` uses configured strategy | Always heuristic |
+
+## Solution
+
+### Step 1: Thread config through planners
+
+Each planner function should accept an optional `config: JetsamConfig | None` parameter.
+If not provided, call `load_config(state.repo_root)` internally.
+
+```python
+def plan_save(
+    state: RepoState,
+    plan_id: str,
+    message: str | None = None,
+    include: str | None = None,
+    exclude: str | None = None,
+    files: list[str] | None = None,
+    config: JetsamConfig | None = None,
+) -> Plan:
+    if config is None:
+        config = load_config(state.repo_root)
+    # ... use config.auto_push, config.commit_message, etc.
+```
+
+### Step 2: Apply config values as defaults
+
+- `plan_save`: If `config.auto_push`, append push step after commit
+- `plan_ship`: Use `config.pr_draft` as default for draft param; use
+  `config.ship_default` to decide PR vs merge; use `config.merge_strategy`
+- `plan_start`: Use `config.branch_prefix` when no explicit prefix given
+- `plan_finish`: Use `config.merge_strategy` as default; use `config.delete_on_merge`
+- `plan_sync`: No config changes needed (strategy already parameterized)
+
+### Step 3: Thread config through MCP tools
+
+MCP tools should load config once per request and pass to planners:
+
+```python
+@mcp.tool()
+def save(message=None, include=None, exclude=None, files=None):
+    state = build_state()
+    config = load_config(state.repo_root)
+    pid = generate_plan_id()
+    plan = plan_save(state, plan_id=pid, message=message, ..., config=config)
+```
+
+### Step 4: Thread config through CLI verbs
+
+CLI verbs should load config and pass to planners similarly.
+
+## Acceptance Criteria
+
+- [ ] All planner functions accept optional `config` parameter
+- [ ] `auto_push` adds push step to `plan_save` output
+- [ ] `pr_draft` sets draft=True on PR creation steps
+- [ ] `ship_default` controls whether `plan_ship` generates PR or merge steps
+- [ ] `merge_strategy` is used as default in `plan_finish` and `plan_ship --merge`
+- [ ] `branch_prefix` is used as default in `plan_start`
+- [ ] `delete_on_merge` is respected in `plan_finish`
+- [ ] CLI verb options override config values (explicit > config > hardcoded default)
+- [ ] Tests for each config option's effect on plan generation
+- [ ] Existing tests still pass (config defaults match current hardcoded behavior)
+
+## Estimated Scope
+
+~50-80 lines across planner.py, tools.py, and CLI verb files. ~15 new tests.
+
+## Dependencies
+
+None — config module already works. This is purely wiring.

--- a/docs/tasks/P6-002-standardize-mcp-error-returns.md
+++ b/docs/tasks/P6-002-standardize-mcp-error-returns.md
@@ -1,0 +1,82 @@
+# P6-002: Standardize MCP Error Returns
+
+**Phase:** 6 — Config & Standardization
+**Priority:** High impact, moderate effort
+**Affects:** `src/jetsam/mcp/tools.py`, `src/jetsam/core/output.py`
+
+## Problem
+
+MCP tools return errors in at least four different formats, forcing agents to handle
+error detection differently per tool:
+
+| Tool | Error Format | Example |
+|---|---|---|
+| `log()` | List-wrapped dict | `[{"error": "..."}]` |
+| `diff()` | Plain dict | `{"error": "..."}` |
+| `pr_view()` | Custom dict | `{"error": "no_platform", "message": "..."}` |
+| `pr_list()` | List-wrapped dict | `[{"error": "no_platform"}]` |
+| `show_plan()` | JetsamError | `{"error": "...", "message": "...", "suggested_action": "...", "recoverable": true}` |
+| `confirm()` | JetsamError | Same as above |
+
+Agents have no consistent way to detect "is this an error response?" across tools.
+
+## Solution
+
+### Define a standard error contract
+
+All MCP tools should use `JetsamError` for error responses. The error dict always has
+`"error"` and `"message"` keys, plus optional `"suggested_action"` and `"recoverable"`.
+
+### For tools returning `dict`:
+
+```python
+# Before
+return {"error": result.stderr.strip()}
+
+# After
+return JetsamError(
+    error="git_error",
+    message=result.stderr.strip(),
+    recoverable=True,
+).to_dict()
+```
+
+### For tools returning `list`:
+
+Tools that return lists should raise or return errors differently from valid results.
+Options:
+- Return `{"error": ..., "items": []}` (wrapper dict)
+- Use MCP's error mechanism if available
+- Keep list return but ensure error items have consistent shape
+
+Recommended: tools returning lists should return an empty list on error and log/surface
+the error via the MCP framework, OR wrap in a dict: `{"items": [...]}` / `{"error": "..."}`.
+
+### Specific changes needed:
+
+1. `log()` — return `JetsamError` dict instead of `[{"error": ...}]`
+2. `diff()` — return `JetsamError` dict instead of `{"error": ...}`
+3. `pr_view()` — use `JetsamError` instead of ad-hoc dict
+4. `pr_list()` — return `JetsamError` dict instead of `[{"error": ...}]`
+5. `checks()` — use `JetsamError` for no_platform and no_pr cases
+6. `issues()` — use `JetsamError` for no_platform case
+
+## Acceptance Criteria
+
+- [ ] All MCP tool error responses use `JetsamError.to_dict()` format
+- [ ] Error responses always have `"error"` and `"message"` keys
+- [ ] Agents can check `if "error" in response` to detect errors uniformly
+- [ ] List-returning tools have a consistent error pattern
+- [ ] MCP tool tests updated to verify error response format
+- [ ] Document the error contract in MCP server instruction string
+
+## Estimated Scope
+
+~30-40 lines changed in `tools.py`. ~10 new/updated tests.
+
+## Notes
+
+Consider whether list-returning tools should change their return type signature to
+`dict` (with an `items` key) so the return type is consistent for success and error.
+This is a breaking change for agents already consuming the tools, so it should be
+weighed carefully.

--- a/docs/tasks/P6-003-plan-to-dict-completeness.md
+++ b/docs/tasks/P6-003-plan-to-dict-completeness.md
@@ -1,0 +1,54 @@
+# P6-003: Include Full Plan Data in to_dict()
+
+**Phase:** 6 — Config & Standardization
+**Priority:** Medium impact, low effort
+**Affects:** `src/jetsam/core/planner.py`
+
+## Problem
+
+`Plan.to_dict()` omits `params`, `state_hash`, and `scope` from the serialized output:
+
+```python
+def to_dict(self) -> dict[str, Any]:
+    return {
+        "plan_id": self.plan_id,
+        "verb": self.verb,
+        "steps": [s.to_dict() for s in self.steps],
+        "warnings": self.warnings,
+    }
+```
+
+But `PlanStore.save()` serializes all fields including `state_hash`, `scope`, and `params`.
+And `update_plan()` reads/writes `params`. This means:
+
+1. The agent can't see the original parameters of a plan it received
+2. The agent can't see which files are in scope
+3. There's no way for the agent to know the state_hash for debugging stale plan errors
+
+## Solution
+
+Include all fields in `to_dict()`:
+
+```python
+def to_dict(self) -> dict[str, Any]:
+    return {
+        "plan_id": self.plan_id,
+        "verb": self.verb,
+        "steps": [s.to_dict() for s in self.steps],
+        "warnings": self.warnings,
+        "params": self.params,
+        "scope": self.scope,
+        "state_hash": self.state_hash,
+    }
+```
+
+## Acceptance Criteria
+
+- [ ] `Plan.to_dict()` includes `params`, `scope`, and `state_hash`
+- [ ] MCP tool responses for plan-returning tools include the new fields
+- [ ] Existing tests updated for the expanded output shape
+- [ ] No breaking changes (new fields are additive)
+
+## Estimated Scope
+
+~3 lines changed in `planner.py`. Update test assertions.

--- a/docs/tasks/P6-004-thread-state-through-executor.md
+++ b/docs/tasks/P6-004-thread-state-through-executor.md
@@ -1,0 +1,68 @@
+# P6-004: Thread State Through Executor
+
+**Phase:** 6 — Config & Standardization
+**Priority:** Medium impact, moderate effort
+**Affects:** `src/jetsam/core/executor.py`
+
+## Problem
+
+`execute_plan()` calls `build_state()` at the top for hash validation (line 101),
+but then several step executors call `build_state()` again internally:
+
+- `_get_platform()` (line 250-256) — called by `_exec_pr_create`, `_exec_pr_merge`,
+  `_exec_release_create`
+- `_exec_pr_merge()` (line 299-301) — calls `build_state()` for branch lookup
+- `_exec_worktree_add()` (line 337-339) — calls `build_state()` for repo_root
+
+Each `build_state()` call runs 6-7 git subprocess commands (~50ms each). In a `ship`
+plan with PR creation, this means 3 redundant state builds (~150ms wasted).
+
+## Solution
+
+Thread the initial `RepoState` through to step executors:
+
+### Step 1: Change executor function signature
+
+```python
+# Step executor type
+StepExecutor = Callable[[PlanStep, str | None, RepoState], StepResult]
+
+def _execute_step(step: PlanStep, cwd: str | None, state: RepoState) -> StepResult:
+    executor = _STEP_EXECUTORS.get(step.action)
+    if executor is None:
+        return StepResult(step=step.action, ok=False, error=f"Unknown: {step.action}")
+    return executor(step, cwd, state)
+```
+
+### Step 2: Update all step executors
+
+Most executors ignore the state parameter. Only the platform-related ones use it:
+
+```python
+def _exec_pr_create(step: PlanStep, cwd: str | None, state: RepoState) -> StepResult:
+    platform = get_platform(state.platform, cwd=cwd)
+    # ... rest unchanged
+```
+
+### Step 3: Remove redundant _get_platform() helper
+
+The helper that calls `build_state()` internally becomes unnecessary.
+
+## Acceptance Criteria
+
+- [ ] `execute_plan()` passes the validated state to all step executors
+- [ ] No step executor calls `build_state()` internally
+- [ ] `_get_platform()` helper in executor.py removed or simplified
+- [ ] All existing tests pass
+- [ ] Measurable performance improvement on plans with platform steps
+
+## Estimated Scope
+
+~40 lines changed in `executor.py`. All executor function signatures gain a `state`
+parameter, but most ignore it.
+
+## Notes
+
+This is a larger refactor touching every executor function signature. The `_STEP_EXECUTORS`
+dict values need to match the new signature. Consider whether backward compatibility
+matters (it shouldn't — these are all internal).

--- a/docs/tasks/P7-001-add-draft-flag-to-ship.md
+++ b/docs/tasks/P7-001-add-draft-flag-to-ship.md
@@ -1,0 +1,60 @@
+# P7-001: Add --draft Flag to Ship CLI
+
+**Phase:** 7 — CLI & Features
+**Priority:** Medium impact, low effort
+**Affects:** `src/jetsam/cli/verbs/ship.py`, `src/jetsam/core/planner.py`
+
+## Problem
+
+The product spec describes draft PR support, and `plan_ship` / `_exec_pr_create`
+already handle a `draft` parameter in plan steps. However, the `ship` CLI verb
+doesn't expose a `--draft` flag, making it impossible to create draft PRs from
+the command line without using `config.pr_draft`.
+
+## Solution
+
+Add `--draft` flag to the ship verb:
+
+```python
+@click.command()
+@click.option("-m", "--message", help="Commit message and PR title")
+@click.option("--draft", is_flag=True, default=False, help="Create PR as draft")
+# ... other options
+def ship(ctx, message, draft, ...):
+    ...
+```
+
+Thread `draft` through to `plan_ship()`, which should pass it to the `pr_create`
+step params.
+
+### Changes to planner.py
+
+`plan_ship` needs a `draft` parameter:
+
+```python
+def plan_ship(
+    state, plan_id, message=None, ..., draft: bool = False,
+) -> Plan:
+    # ...
+    if open_pr and not state.pr:
+        steps.append(PlanStep(
+            action="pr_create",
+            params={"title": message or state.branch, "base": target_branch, "draft": draft},
+        ))
+```
+
+## Acceptance Criteria
+
+- [ ] `jetsam ship --draft -m "wip"` creates a draft PR
+- [ ] `draft` parameter flows from CLI → planner → plan step → executor
+- [ ] Config `pr_draft` serves as default when `--draft` not specified (depends on P6-001)
+- [ ] MCP `ship()` tool already has draft support or gets it added
+- [ ] Test for `plan_ship` with `draft=True`
+
+## Estimated Scope
+
+~5 lines in `ship.py`, ~5 lines in `planner.py`, 1-2 new tests.
+
+## Dependencies
+
+- P6-001 (Wire config) — for `pr_draft` config default, but `--draft` flag works standalone

--- a/docs/tasks/P7-002-cli-edit-flow.md
+++ b/docs/tasks/P7-002-cli-edit-flow.md
@@ -1,0 +1,80 @@
+# P7-002: Implement CLI Edit Flow for Plans
+
+**Phase:** 7 — CLI & Features
+**Priority:** Medium impact, moderate effort
+**Affects:** `src/jetsam/cli/verbs/` (save, ship, sync, start, finish, release, tidy)
+
+## Problem
+
+The product spec describes a three-option interactive flow:
+
+```
+[e]dit / [c]onfirm / [a]bort: e
+exclude> test_parser.cpp
+```
+
+The current implementation only offers `[c]onfirm / [a]bort`. Users can't modify a
+plan interactively before confirming it from the CLI.
+
+## Solution
+
+### Step 1: Add edit option to confirmation prompt
+
+```python
+# Current
+choice = click.prompt("[c]onfirm / [a]bort", type=click.Choice(["c", "a"]))
+
+# Proposed
+choice = click.prompt("[e]dit / [c]onfirm / [a]bort", type=click.Choice(["e", "c", "a"]))
+```
+
+### Step 2: Implement edit loop
+
+When `e` is selected, prompt for modifications based on the verb:
+
+**For save/ship (file-based verbs):**
+- `exclude> <pattern>` — remove files matching glob from stage step
+- `message> <text>` — change commit message
+- Show updated plan after each edit
+- Return to `[e]dit / [c]onfirm / [a]bort` prompt
+
+**For sync:**
+- `strategy> <rebase|merge>` — change integration strategy
+- Show updated plan
+
+**For other verbs:**
+- `message> <text>` — change commit message (where applicable)
+
+### Step 3: Use update_plan() from plans.py
+
+The edit loop should use `update_plan()` to modify the plan, which already handles
+message changes and file exclusion.
+
+### Step 4: Extract shared prompt logic
+
+Since 7+ verbs use the same confirm pattern, extract a shared function:
+
+```python
+def confirm_or_edit_plan(plan: Plan, json_mode: bool, dry_run: bool) -> Plan | None:
+    """Show plan, prompt for confirm/edit/abort. Returns final plan or None."""
+    ...
+```
+
+## Acceptance Criteria
+
+- [ ] `[e]dit` option available in all plan-based verbs
+- [ ] Edit loop supports `exclude>` and `message>` modifications
+- [ ] Updated plan is displayed after each edit
+- [ ] Edit loop can be repeated (multiple edits before confirm)
+- [ ] `--execute` and `--json` modes skip the edit flow (same as current)
+- [ ] Shared confirm/edit function reduces duplication across verbs
+- [ ] Tests for edit flow (at minimum: exclude a file, change message)
+
+## Estimated Scope
+
+~100-150 lines: shared confirm function (~60 lines), updates to each verb (~5 lines each),
+tests (~40 lines).
+
+## Dependencies
+
+None — `update_plan()` already exists in `plans.py`.

--- a/docs/tasks/P7-003-add-config-verb.md
+++ b/docs/tasks/P7-003-add-config-verb.md
@@ -1,0 +1,100 @@
+# P7-003: Add Config Verb
+
+**Phase:** 7 — CLI & Features
+**Priority:** Low-medium impact, moderate effort
+**Affects:** New file `src/jetsam/cli/verbs/config.py`, `src/jetsam/config/manager.py`
+
+## Problem
+
+The product spec lists a `config` management command for viewing and setting preferences.
+Currently, users must manually edit `.jetsam/config.yaml` to change configuration.
+There's no way to view the active (merged) configuration from the CLI.
+
+## Solution
+
+### `jetsam config` — View current configuration
+
+```bash
+$ jetsam config
+  platform: auto (detected: github)
+  merge_strategy: squash
+  auto_push: false
+  ship_default: pr
+  pr_draft: false
+  branch_prefix: ""
+  delete_on_merge: true
+  worktree: auto
+  commit_message: heuristic
+
+  Source: .jetsam/config.yaml
+```
+
+### `jetsam config <key>` — View a single value
+
+```bash
+$ jetsam config merge_strategy
+squash
+```
+
+### `jetsam config <key> <value>` — Set a value
+
+```bash
+$ jetsam config merge_strategy rebase
+  Set merge_strategy = rebase in .jetsam/config.yaml
+```
+
+### `jetsam config --global <key> <value>` — Set globally
+
+```bash
+$ jetsam config --global branch_prefix "teague/"
+  Set branch_prefix = "teague/" in ~/.config/jetsam/config.yaml
+```
+
+### Implementation
+
+1. Create `src/jetsam/cli/verbs/config.py`
+2. Add `save_config()` function to `config/manager.py`
+3. Register in `cli/main.py`
+
+### Config writing function
+
+```python
+def save_config(config_path: str, key: str, value: Any) -> None:
+    """Write a single key to a YAML config file."""
+    path = Path(config_path)
+    data = {}
+    if path.exists():
+        with open(path) as f:
+            data = yaml.safe_load(f) or {}
+    data[key] = value
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        yaml.dump(data, f, default_flow_style=False)
+```
+
+### JSON mode
+
+```bash
+$ jetsam --json config
+{"platform": "auto", "merge_strategy": "squash", ...}
+```
+
+## Acceptance Criteria
+
+- [ ] `jetsam config` displays all active configuration
+- [ ] `jetsam config <key>` displays a single value
+- [ ] `jetsam config <key> <value>` writes to `.jetsam/config.yaml`
+- [ ] `jetsam config --global <key> <value>` writes to `~/.config/jetsam/config.yaml`
+- [ ] `--json` support for all config operations
+- [ ] Config file is created if it doesn't exist
+- [ ] Invalid keys are rejected with a helpful error
+- [ ] Values are type-validated (bool, str, etc.)
+- [ ] Tests for read, write, and validation
+
+## Estimated Scope
+
+~80-100 lines for the verb, ~20 lines for `save_config()`, ~30 lines of tests.
+
+## Dependencies
+
+- P6-001 (Wire config) — config verb is more useful when config actually affects behavior

--- a/docs/tasks/P8-001-reorganize-test-files.md
+++ b/docs/tasks/P8-001-reorganize-test-files.md
@@ -1,0 +1,76 @@
+# P8-001: Reorganize Phase Test Files by Feature
+
+**Phase:** 8 — Testing & Polish
+**Priority:** Low-medium impact, moderate effort
+**Affects:** `tests/test_phase2.py`, `tests/test_phase3.py`, `tests/test_phase4.py`
+
+## Problem
+
+Tests are organized by implementation phase (test_phase2.py, test_phase3.py,
+test_phase4.py) rather than by feature. Now that all phases are complete, this
+organization makes it harder to find tests for a specific feature:
+
+- Want to find all `ship` tests? They're in test_phase2.py alongside `switch`,
+  `checks`, `pr`, and `init` tests.
+- Want to find all `start`/`finish` tests? They're in test_phase3.py alongside
+  `tidy`, `issues`, `completions`, and `slugify` tests.
+- Want to find all `release` tests? They're in test_phase4.py alongside alias
+  generation, worktree shared paths, and error recovery tests.
+
+## Solution
+
+Split the phase files into feature-focused test modules:
+
+### From test_phase2.py (35 tests):
+- `test_ship.py` — Ship verb tests
+- `test_switch.py` — Switch verb tests
+- `test_pr.py` — PR verb tests
+- `test_checks.py` — Checks verb tests
+- `test_init.py` — Init verb tests
+- Executor tests → merge into `test_executor.py`
+
+### From test_phase3.py (48 tests):
+- `test_start.py` — Start verb tests
+- `test_finish.py` — Finish verb tests
+- `test_tidy.py` — Tidy verb tests
+- `test_issues.py` — Issues verb tests
+- `test_prs.py` — PRs list verb tests
+- `test_completions.py` — Completions tests
+- `test_slugify.py` — Slug generation tests (or merge into test_planner.py)
+
+### From test_phase4.py (35 tests):
+- `test_release.py` — Release verb tests
+- `test_aliases.py` — Alias system tests
+- `test_error_recovery.py` — Error recovery suggestion tests
+- Worktree shared paths → merge into `test_worktree.py`
+
+### Keep existing focused test files as-is:
+- `test_smoke.py`, `test_state.py`, `test_config.py`, `test_git_wrapper.py`,
+  `test_parsers.py`, `test_output.py`, `test_planner.py`, `test_executor.py`,
+  `test_cli_verbs.py`, `test_mcp_tools.py`, `test_integration.py`,
+  `test_worktree.py`, `test_platform_github.py`, `test_platform_gitlab.py`
+
+## Acceptance Criteria
+
+- [ ] Each test file maps to one feature or module
+- [ ] All 269 tests still pass
+- [ ] No duplicate test names
+- [ ] Remove empty test_phase*.py files
+- [ ] Shared fixtures remain in conftest.py (no duplication)
+- [ ] Test counts are preserved (no accidentally dropped tests)
+
+## Estimated Scope
+
+Pure file reorganization — no logic changes. ~1-2 hours of careful cut/paste.
+
+## Risks
+
+- Test discovery changes if test names collide across new files
+- Shared setup within phase files (class-level) needs to be preserved
+- Git blame history is lost for moved tests (acceptable)
+
+## Notes
+
+This is a housekeeping task. It can be deferred indefinitely without impacting
+functionality, but it pays dividends every time someone needs to find or modify
+tests for a specific feature.

--- a/docs/tasks/P8-002-negative-path-platform-tests.md
+++ b/docs/tasks/P8-002-negative-path-platform-tests.md
@@ -1,0 +1,96 @@
+# P8-002: Add Negative Path Tests for Platform Adapters
+
+**Phase:** 8 — Testing & Polish
+**Priority:** Medium impact, moderate effort
+**Affects:** `tests/test_platform_github.py`, `tests/test_platform_gitlab.py`
+
+## Problem
+
+Current platform adapter tests are primarily happy-path: they verify correct parsing
+of well-formed JSON responses. There are no tests for:
+
+1. **Malformed JSON** from `gh`/`glab` (e.g., truncated output, HTML error pages)
+2. **Missing fields** in JSON responses (e.g., API version changes)
+3. **Network errors** (subprocess timeout, connection refused)
+4. **Authentication failures** (expired token, revoked access)
+5. **Rate limiting** (429 responses surfaced through CLI)
+6. **Unexpected status codes** from platform CLIs
+7. **Command not found** (gh/glab not installed)
+
+The platform adapters have defensive coding (try/except, isinstance checks), but
+these paths are untested.
+
+## Solution
+
+### Test categories to add:
+
+#### 1. Command not found
+
+```python
+def test_gh_not_installed(self, monkeypatch):
+    """GitHubPlatform handles missing gh gracefully."""
+    # Mock subprocess.run to raise FileNotFoundError
+    platform = GitHubPlatform()
+    assert platform.is_available() is False
+    assert platform.pr_for_branch("main") is None
+```
+
+#### 2. Malformed output
+
+```python
+def test_pr_view_html_error(self, monkeypatch):
+    """Handle gh returning HTML error page instead of JSON."""
+    # Mock gh to return HTML
+    result = platform.pr_for_branch("main")
+    assert result is None
+```
+
+#### 3. Missing fields
+
+```python
+def test_pr_parse_minimal_json(self):
+    """Parse PR with only required fields present."""
+    data = {"number": 1, "state": "open", "title": "test"}
+    pr = _parse_pr(data)
+    assert pr.number == 1
+    assert pr.labels == []  # default
+    assert pr.draft is False  # default
+```
+
+#### 4. Auth failure
+
+```python
+def test_pr_create_auth_failure(self, monkeypatch):
+    """PlatformError raised when gh auth is expired."""
+    # Mock gh to return auth error
+    with pytest.raises(PlatformError, match="auth"):
+        platform.pr_create(title="test")
+```
+
+#### 5. GitLab-specific edge cases
+
+```python
+def test_gitlab_mr_opened_vs_open(self):
+    """GitLab returns 'opened' instead of 'open' - verify normalization."""
+
+def test_gitlab_iid_vs_id(self):
+    """GitLab uses iid (project-scoped) - verify correct field extraction."""
+```
+
+## Acceptance Criteria
+
+- [ ] Tests for `gh`/`glab` not installed (FileNotFoundError)
+- [ ] Tests for malformed JSON output (JSONDecodeError)
+- [ ] Tests for missing/extra fields in API responses
+- [ ] Tests for PlatformError propagation from pr_create/release_create
+- [ ] Tests for `is_available()` failure modes
+- [ ] Tests for GitLab state normalization edge cases
+- [ ] All new tests use mocking (no real gh/glab calls)
+
+## Estimated Scope
+
+~20-30 new tests, ~150-200 lines across the two platform test files.
+
+## Dependencies
+
+- P5-002 (Consolidate PlatformError) — tests should import from base.py

--- a/docs/tasks/P8-003-add-structured-logging.md
+++ b/docs/tasks/P8-003-add-structured-logging.md
@@ -1,0 +1,102 @@
+# P8-003: Add Structured Logging
+
+**Phase:** 8 — Testing & Polish
+**Priority:** Low-medium impact, moderate effort
+**Affects:** Multiple source files
+
+## Problem
+
+The codebase uses `click.echo()` exclusively for output. There is no `logging` module
+usage anywhere. This creates problems for:
+
+1. **MCP server debugging** — stdout is the MCP transport, so any debug output
+   corrupts the protocol. There's no way to get diagnostic output from the server.
+2. **CI debugging** — when tests fail or behavior is unexpected, there's no trace
+   of what git commands were run or what state was detected.
+3. **User debugging** — when a plan fails, users have no verbose mode to see
+   what happened internally.
+
+## Solution
+
+### Step 1: Add logging to key modules
+
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+```
+
+**Where to log:**
+
+| Module | What to log | Level |
+|---|---|---|
+| `git/wrapper.py` | Git commands run and their exit codes | DEBUG |
+| `core/state.py` | State snapshot contents | DEBUG |
+| `core/executor.py` | Step execution start/end, results | DEBUG |
+| `core/planner.py` | Plan generation decisions | DEBUG |
+| `core/plans.py` | Plan save/load/expire events | DEBUG |
+| `platforms/*.py` | Platform CLI commands and responses | DEBUG |
+| `config/manager.py` | Config file locations and merge | DEBUG |
+
+### Step 2: Add --verbose flag to CLI
+
+```python
+@click.group(cls=JetsamGroup)
+@click.option("-v", "--verbose", is_flag=True, help="Enable debug logging")
+def cli(ctx, json_output, verbose):
+    if verbose:
+        logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)
+```
+
+Key: logging goes to stderr, never stdout. This keeps JSON output and MCP
+transport clean.
+
+### Step 3: Configure logging for MCP server
+
+```python
+# mcp/server.py
+def serve_stdio():
+    logging.basicConfig(
+        level=logging.WARNING,
+        stream=sys.stderr,
+        format="%(name)s %(levelname)s: %(message)s",
+    )
+```
+
+The MCP server defaults to WARNING level (quiet), but can be configured
+via environment variable:
+
+```bash
+JETSAM_LOG_LEVEL=debug jetsam serve
+```
+
+## Acceptance Criteria
+
+- [ ] `logging` module used in all core modules
+- [ ] All log output goes to stderr (never stdout)
+- [ ] `jetsam -v status` shows debug output
+- [ ] MCP server doesn't pollute stdout with log messages
+- [ ] Log format includes module name and level
+- [ ] `JETSAM_LOG_LEVEL` environment variable supported
+- [ ] No performance impact when logging is disabled (lazy formatting)
+
+## Estimated Scope
+
+~5-10 lines per module (8 modules = ~60-80 lines total). CLI flag ~5 lines.
+No changes to existing behavior when verbose is off.
+
+## Notes
+
+Use lazy string formatting to avoid performance impact:
+
+```python
+# Good (no formatting cost if DEBUG disabled)
+logger.debug("Running git %s", args)
+
+# Bad (always formats)
+logger.debug(f"Running git {args}")
+```
+
+## Dependencies
+
+None.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -1,0 +1,64 @@
+# Task Plans
+
+Post-v0.1 improvement tasks identified from a systematic code review.
+Phases continue from the original implementation phases (1-4).
+
+## Phase 5 — Quick Wins & Code Quality
+
+High-impact, low-effort fixes. No architectural changes.
+
+| Task | Description | Effort |
+|------|-------------|--------|
+| [P5-001](P5-001-fix-sha-extraction.md) | Fix fragile SHA extraction in executor | ~5 lines |
+| [P5-002](P5-002-consolidate-platform-error.md) | Consolidate PlatformError into base module | ~10 lines |
+| [P5-003](P5-003-add-py-typed-marker.md) | Add py.typed marker for PEP 561 | 1 file |
+| [P5-004](P5-004-add-test-coverage.md) | Add test coverage measurement | Config only |
+| [P5-005](P5-005-trigger-plan-cleanup.md) | Trigger cleanup of expired plans | ~10 lines |
+
+## Phase 6 — Config & Standardization
+
+Wire config into planners, standardize error handling, improve data completeness.
+
+| Task | Description | Effort |
+|------|-------------|--------|
+| [P6-001](P6-001-wire-config-into-planners.md) | Wire JetsamConfig into all planners | ~80 lines + tests |
+| [P6-002](P6-002-standardize-mcp-error-returns.md) | Standardize MCP tool error returns | ~40 lines + tests |
+| [P6-003](P6-003-plan-to-dict-completeness.md) | Include full plan data in to_dict() | ~3 lines |
+| [P6-004](P6-004-thread-state-through-executor.md) | Thread RepoState through executor | ~40 lines |
+
+## Phase 7 — CLI & Features
+
+New CLI capabilities from the product spec.
+
+| Task | Description | Effort |
+|------|-------------|--------|
+| [P7-001](P7-001-add-draft-flag-to-ship.md) | Add --draft flag to ship verb | ~10 lines |
+| [P7-002](P7-002-cli-edit-flow.md) | Implement interactive edit flow for plans | ~150 lines |
+| [P7-003](P7-003-add-config-verb.md) | Add config view/set verb | ~100 lines |
+
+## Phase 8 — Testing & Polish
+
+Test improvements and developer experience.
+
+| Task | Description | Effort |
+|------|-------------|--------|
+| [P8-001](P8-001-reorganize-test-files.md) | Reorganize phase test files by feature | File moves |
+| [P8-002](P8-002-negative-path-platform-tests.md) | Add negative path tests for platforms | ~200 lines |
+| [P8-003](P8-003-add-structured-logging.md) | Add structured logging to stderr | ~80 lines |
+
+## Dependency Graph
+
+```
+P5-* ──── no dependencies (can be done in any order)
+
+P6-001 ←── P7-001 (draft flag uses config defaults)
+P6-001 ←── P7-003 (config verb more useful when config is wired in)
+P5-002 ←── P8-002 (platform tests should import consolidated error)
+
+P6-002 ──── no dependencies
+P6-003 ──── no dependencies
+P6-004 ──── no dependencies
+P7-002 ──── no dependencies
+P8-001 ──── no dependencies
+P8-003 ──── no dependencies
+```


### PR DESCRIPTION
## Summary

- 15 task plans across phases 5-8 from a systematic code review of the entire codebase
- Covers code quality fixes, config wiring, MCP error standardization, new CLI features, and test improvements
- Organized with dependency graph and effort estimates for delegation

### Phase breakdown

| Phase | Focus | Tasks |
|-------|-------|-------|
| P5 | Quick wins & code quality | 5 (SHA fix, PlatformError consolidation, py.typed, coverage, plan cleanup) |
| P6 | Config & standardization | 4 (config wiring, MCP errors, Plan.to_dict, executor state threading) |
| P7 | CLI & features | 3 (--draft flag, interactive edit flow, config verb) |
| P8 | Testing & polish | 3 (test reorg, negative path tests, structured logging) |

See [docs/tasks/README.md](docs/tasks/README.md) for the full index and dependency graph.

## Test plan

- [ ] No code changes — documentation only, existing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)