### PR TITLE
feat: standardize MCP error returns (P6-002)

### DIFF
--- a/docs/superpowers/plans/2026-03-22-standardize-mcp-errors.md
+++ b/docs/superpowers/plans/2026-03-22-standardize-mcp-errors.md
@@ -1,0 +1,637 @@
+# P6-002: Standardize MCP Error Returns — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Standardize all MCP tool error responses to use `JetsamError.to_dict()` so agents can detect errors uniformly via `if "error" in response`.
+
+**Architecture:** Add two helper functions (`_no_platform_error`, `_no_pr_error`) to `tools.py`, then replace all ad-hoc error returns with `JetsamError.to_dict()` calls. Update the MCP server instruction string to document the error contract. TDD throughout.
+
+**Tech Stack:** Python, pytest, FastMCP
+
+**Spec:** `docs/superpowers/specs/2026-03-22-standardize-mcp-errors-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/jetsam/mcp/tools.py` | Modify | Add helpers, replace all ad-hoc error returns |
+| `src/jetsam/mcp/server.py` | Modify | Update instruction string |
+| `tests/test_mcp_tools.py` | Modify | Add error-format tests |
+
+---
+
+### Task 1: Add helper functions and test infrastructure
+
+**Files:**
+- Modify: `src/jetsam/mcp/tools.py:30-36` (add helpers after `_plan_store`)
+- Modify: `tests/test_mcp_tools.py` (add error-format test helpers)
+
+- [ ] **Step 1: Write tests for helper functions**
+
+Add a new test class at the end of `tests/test_mcp_tools.py`:
+
+```python
+class TestErrorHelpers:
+    """Test the error helper functions produce standard JetsamError format."""
+
+    def test_no_platform_error(self):
+        from jetsam.mcp.tools import _no_platform_error
+
+        result = _no_platform_error()
+        assert result["error"] == "no_platform"
+        assert "message" in result
+        assert result["recoverable"] is False
+
+    def test_no_pr_error(self):
+        from jetsam.mcp.tools import _no_pr_error
+
+        result = _no_pr_error("feature/foo")
+        assert result["error"] == "no_pr"
+        assert "feature/foo" in result["message"]
+        assert result["recoverable"] is True
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_mcp_tools.py::TestErrorHelpers -v`
+Expected: FAIL — `_no_platform_error` and `_no_pr_error` do not exist yet.
+
+- [ ] **Step 3: Implement helpers**
+
+Add after the `_get_store()` function (around line 44) in `src/jetsam/mcp/tools.py`:
+
+```python
+def _no_platform_error() -> dict[str, Any]:
+    """Standard error for missing platform configuration."""
+    return JetsamError(
+        error="no_platform",
+        message="No platform configured.",
+        suggested_action="Configure a GitHub or GitLab remote.",
+        recoverable=False,
+    ).to_dict()
+
+
+def _no_pr_error(branch: str) -> dict[str, Any]:
+    """Standard error for missing PR."""
+    return JetsamError(
+        error="no_pr",
+        message=f"No PR found for branch '{branch}'.",
+        recoverable=True,
+    ).to_dict()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_mcp_tools.py::TestErrorHelpers -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/jetsam/mcp/tools.py tests/test_mcp_tools.py
+git commit -m "feat(mcp): add _no_platform_error and _no_pr_error helpers"
+```
+
+---
+
+### Task 2: Standardize `log()` and `diff()` error returns
+
+**Files:**
+- Modify: `src/jetsam/mcp/tools.py:130-183` (`log` and `diff` functions)
+- Modify: `tests/test_mcp_tools.py` (add error format tests)
+
+- [ ] **Step 1: Write tests for log and diff error paths**
+
+Add to `tests/test_mcp_tools.py`:
+
+```python
+class TestErrorFormats:
+    """Verify all error paths return standard JetsamError dicts."""
+
+    def test_log_error_returns_jetsam_error_dict(
+        self, tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """log() should return a JetsamError dict, not a list, on error."""
+        monkeypatch.setenv("GIT_DIR", str(tmp_git_repo / ".git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(tmp_git_repo))
+
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        mcp_tools.register_tools(mcp)
+
+        # Access the registered tool function
+        log_fn = mcp._tool_manager._tools["log"].fn
+        result = log_fn(n=10, branch="nonexistent-branch-xyz")
+
+        assert isinstance(result, dict), "Error should be a dict, not a list"
+        assert result["error"] == "git_error"
+        assert "message" in result
+        assert "recoverable" in result
+
+    def test_diff_stat_error_returns_jetsam_error_dict(
+        self, tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """diff() in stat mode should return JetsamError dict on error."""
+        monkeypatch.setenv("GIT_DIR", str(tmp_git_repo / ".git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(tmp_git_repo))
+
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        mcp_tools.register_tools(mcp)
+
+        diff_fn = mcp._tool_manager._tools["diff"].fn
+        result = diff_fn(target="nonexistent-ref-xyz", stat=True, staged=False)
+
+        assert isinstance(result, dict)
+        assert result["error"] == "git_error"
+        assert "message" in result
+        assert "recoverable" in result
+
+    def test_diff_full_error_returns_jetsam_error_dict(
+        self, tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """diff() in full mode should return JetsamError dict on error."""
+        monkeypatch.setenv("GIT_DIR", str(tmp_git_repo / ".git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(tmp_git_repo))
+
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        mcp_tools.register_tools(mcp)
+
+        diff_fn = mcp._tool_manager._tools["diff"].fn
+        result = diff_fn(target="nonexistent-ref-xyz", stat=False, staged=False)
+
+        assert isinstance(result, dict)
+        assert result["error"] == "git_error"
+        assert "message" in result
+        assert "recoverable" in result
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_mcp_tools.py::TestErrorFormats -v`
+Expected: FAIL — `log()` returns a list, `diff()` returns ad-hoc dicts.
+
+- [ ] **Step 3: Update `log()` error return**
+
+In `src/jetsam/mcp/tools.py`, change the `log()` error path (around line 143-144):
+
+```python
+# Before:
+        if not result.ok:
+            return [{"error": result.stderr.strip()}]
+
+# After:
+        if not result.ok:
+            return JetsamError(
+                error="git_error",
+                message=result.stderr.strip(),
+                recoverable=True,
+            ).to_dict()
+```
+
+- [ ] **Step 4: Update `diff()` error returns**
+
+In `src/jetsam/mcp/tools.py`, change both `diff()` error paths:
+
+Stat mode (around line 170-171):
+```python
+# Before:
+            if not result.ok:
+                return {"error": result.stderr.strip()}
+
+# After:
+            if not result.ok:
+                return JetsamError(
+                    error="git_error",
+                    message=result.stderr.strip(),
+                    recoverable=True,
+                ).to_dict()
+```
+
+Full mode (around line 182-183):
+```python
+# Before:
+            result = run_git_sync(args)
+            return {"diff": result.stdout, "ok": result.ok}
+
+# After:
+            result = run_git_sync(args)
+            if not result.ok:
+                return JetsamError(
+                    error="git_error",
+                    message=result.stderr.strip(),
+                    recoverable=True,
+                ).to_dict()
+            return {"diff": result.stdout, "ok": result.ok}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest tests/test_mcp_tools.py::TestErrorFormats -v`
+Expected: PASS
+
+- [ ] **Step 6: Run full test suite to check for regressions**
+
+Run: `pytest tests/test_mcp_tools.py -v`
+Expected: All tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/jetsam/mcp/tools.py tests/test_mcp_tools.py
+git commit -m "feat(mcp): standardize log() and diff() error returns to JetsamError"
+```
+
+---
+
+### Task 3: Standardize platform-dependent tool error returns
+
+These tools all share the same `no_platform` / `no_pr` error patterns:
+`pr_view`, `pr_list`, `pr_comment`, `pr_review`, `pr_comments`, `checks`, `issues`, `issue_close`.
+
+**Files:**
+- Modify: `src/jetsam/mcp/tools.py:200-427` (platform-dependent tools)
+- Modify: `tests/test_mcp_tools.py` (add platform error tests)
+
+- [ ] **Step 1: Write tests for no_platform errors**
+
+Add to `TestErrorFormats` in `tests/test_mcp_tools.py`:
+
+```python
+    def test_pr_view_no_platform_returns_jetsam_error(
+        self, tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("GIT_DIR", str(tmp_git_repo / ".git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(tmp_git_repo))
+        # No platform configured in tmp_git_repo
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        mcp_tools.register_tools(mcp)
+
+        pr_view_fn = mcp._tool_manager._tools["pr_view"].fn
+        result = pr_view_fn(branch=None)
+
+        assert isinstance(result, dict)
+        assert result["error"] == "no_platform"
+        assert "message" in result
+        assert "recoverable" in result
+
+    def test_pr_list_no_platform_returns_jetsam_error_dict(
+        self, tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """pr_list() should return a dict (not list) on error."""
+        monkeypatch.setenv("GIT_DIR", str(tmp_git_repo / ".git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(tmp_git_repo))
+
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        mcp_tools.register_tools(mcp)
+
+        pr_list_fn = mcp._tool_manager._tools["pr_list"].fn
+        result = pr_list_fn(state="open", author=None)
+
+        assert isinstance(result, dict), "Error should be a dict, not a list"
+        assert result["error"] == "no_platform"
+        assert "message" in result
+        assert "recoverable" in result
+
+    def test_checks_no_platform_returns_jetsam_error_dict(
+        self, tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("GIT_DIR", str(tmp_git_repo / ".git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(tmp_git_repo))
+
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        mcp_tools.register_tools(mcp)
+
+        checks_fn = mcp._tool_manager._tools["checks"].fn
+        result = checks_fn(pr_number=None)
+
+        assert isinstance(result, dict), "Error should be a dict, not a list"
+        assert result["error"] == "no_platform"
+        assert "message" in result
+
+    def test_issues_no_platform_returns_jetsam_error_dict(
+        self, tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("GIT_DIR", str(tmp_git_repo / ".git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(tmp_git_repo))
+
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        mcp_tools.register_tools(mcp)
+
+        issues_fn = mcp._tool_manager._tools["issues"].fn
+        result = issues_fn(state="open", labels=None)
+
+        assert isinstance(result, dict), "Error should be a dict, not a list"
+        assert result["error"] == "no_platform"
+        assert "message" in result
+
+    def test_pr_comments_no_platform_returns_jetsam_error_dict(
+        self, tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("GIT_DIR", str(tmp_git_repo / ".git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(tmp_git_repo))
+
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        mcp_tools.register_tools(mcp)
+
+        fn = mcp._tool_manager._tools["pr_comments"].fn
+        result = fn(branch=None, pr_number=None)
+
+        assert isinstance(result, dict), "Error should be a dict, not a list"
+        assert result["error"] == "no_platform"
+        assert "message" in result
+
+    def test_pr_comment_no_platform_returns_jetsam_error(
+        self, tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("GIT_DIR", str(tmp_git_repo / ".git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(tmp_git_repo))
+
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        mcp_tools.register_tools(mcp)
+
+        fn = mcp._tool_manager._tools["pr_comment"].fn
+        result = fn(body="test", branch=None, pr_number=None)
+
+        assert isinstance(result, dict)
+        assert result["error"] == "no_platform"
+        assert "message" in result
+
+    def test_pr_review_no_platform_returns_jetsam_error(
+        self, tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("GIT_DIR", str(tmp_git_repo / ".git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(tmp_git_repo))
+
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        mcp_tools.register_tools(mcp)
+
+        fn = mcp._tool_manager._tools["pr_review"].fn
+        result = fn(event="approve", body="", branch=None, pr_number=None)
+
+        assert isinstance(result, dict)
+        assert result["error"] == "no_platform"
+        assert "message" in result
+
+    def test_issue_close_no_platform_returns_jetsam_error(
+        self, tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("GIT_DIR", str(tmp_git_repo / ".git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(tmp_git_repo))
+
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        mcp_tools.register_tools(mcp)
+
+        fn = mcp._tool_manager._tools["issue_close"].fn
+        result = fn(number=999, comment=None, reason="completed")
+
+        assert isinstance(result, dict)
+        assert result["error"] == "no_platform"
+        assert "message" in result
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_mcp_tools.py::TestErrorFormats -v -k "no_platform"`
+Expected: FAIL — current code returns ad-hoc dicts or list-wrapped errors.
+
+- [ ] **Step 3: Replace all `no_platform` error returns with `_no_platform_error()`**
+
+In `src/jetsam/mcp/tools.py`, replace each `no_platform` error return:
+
+`pr_view()` (around line 210):
+```python
+# Before:
+        if platform is None:
+            return {"error": "no_platform", "message": "No platform configured"}
+# After:
+        if platform is None:
+            return _no_platform_error()
+```
+
+`pr_list()` (around line 230):
+```python
+# Before:
+        if platform is None:
+            return [{"error": "no_platform"}]
+# After:
+        if platform is None:
+            return _no_platform_error()
+```
+
+`checks()` (around line 244):
+```python
+# Before:
+        if platform is None:
+            return [{"error": "no_platform"}]
+# After:
+        if platform is None:
+            return _no_platform_error()
+```
+
+`issues()` (around line 340):
+```python
+# Before:
+        if platform is None:
+            return [{"error": "no_platform"}]
+# After:
+        if platform is None:
+            return _no_platform_error()
+```
+
+`pr_comment()` (around line 360):
+```python
+# Before:
+        if platform is None:
+            return {"error": "no_platform", "message": "No platform configured"}
+# After:
+        if platform is None:
+            return _no_platform_error()
+```
+
+`pr_review()` (around line 390):
+```python
+# Before:
+        if platform is None:
+            return {"error": "no_platform", "message": "No platform configured"}
+# After:
+        if platform is None:
+            return _no_platform_error()
+```
+
+`pr_comments()` (around line 416):
+```python
+# Before:
+        if platform is None:
+            return [{"error": "no_platform"}]
+# After:
+        if platform is None:
+            return _no_platform_error()
+```
+
+`issue_close()` (around line 444):
+```python
+# Before:
+        if platform is None:
+            return {"error": "no_platform", "message": "No platform configured"}
+# After:
+        if platform is None:
+            return _no_platform_error()
+```
+
+- [ ] **Step 4: Replace all `no_pr` error returns with `_no_pr_error()`**
+
+`checks()` (around line 250):
+```python
+# Before:
+            if pr is None:
+                return [{"error": "no_pr", "branch": repo_state.branch}]
+# After:
+            if pr is None:
+                return _no_pr_error(repo_state.branch)
+```
+
+`pr_comment()` (around line 367):
+```python
+# Before:
+            if pr is None:
+                return {"error": "no_pr", "branch": actual_branch}
+# After:
+            if pr is None:
+                return _no_pr_error(actual_branch)
+```
+
+`pr_review()` (around line 396):
+```python
+# Before:
+            if pr is None:
+                return {"error": "no_pr", "branch": actual_branch}
+# After:
+            if pr is None:
+                return _no_pr_error(actual_branch)
+```
+
+`pr_comments()` (around line 423):
+```python
+# Before:
+            if pr is None:
+                return [{"error": "no_pr", "branch": actual_branch}]
+# After:
+            if pr is None:
+                return _no_pr_error(actual_branch)
+```
+
+- [ ] **Step 5: Write test for `no_pr` error path with mocked platform**
+
+Add to `TestErrorFormats` in `tests/test_mcp_tools.py`:
+
+```python
+    def test_checks_no_pr_returns_jetsam_error_dict(
+        self, tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """checks() should return JetsamError dict when no PR exists."""
+        monkeypatch.setenv("GIT_DIR", str(tmp_git_repo / ".git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(tmp_git_repo))
+
+        from unittest.mock import MagicMock
+
+        from mcp.server.fastmcp import FastMCP
+
+        # Mock platform that returns None for pr_for_branch
+        mock_platform = MagicMock()
+        mock_platform.pr_for_branch.return_value = None
+        monkeypatch.setattr(mcp_tools, "_get_platform", lambda _: mock_platform)
+
+        mcp = FastMCP("test")
+        mcp_tools.register_tools(mcp)
+
+        checks_fn = mcp._tool_manager._tools["checks"].fn
+        result = checks_fn(pr_number=None)
+
+        assert isinstance(result, dict), "Error should be a dict, not a list"
+        assert result["error"] == "no_pr"
+        assert "message" in result
+        assert "recoverable" in result
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pytest tests/test_mcp_tools.py::TestErrorFormats -v`
+Expected: All PASS.
+
+- [ ] **Step 7: Run full test suite**
+
+Run: `pytest tests/test_mcp_tools.py -v`
+Expected: All tests PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/jetsam/mcp/tools.py tests/test_mcp_tools.py
+git commit -m "feat(mcp): standardize platform tool errors to JetsamError format"
+```
+
+---
+
+### Task 4: Update MCP server instructions and final verification
+
+**Files:**
+- Modify: `src/jetsam/mcp/server.py:9-14`
+
+- [ ] **Step 1: Update instruction string**
+
+In `src/jetsam/mcp/server.py`, update the `instructions` parameter:
+
+```python
+# Before:
+mcp = FastMCP("jetsam", instructions=(
+    "jetsam is a git workflow accelerator. "
+    "Use workflow tools (status, save, sync, log, diff) for common operations. "
+    "Mutating tools (save, sync) return plans that must be confirmed with confirm(). "
+    "Use the git tool for any git operation not covered by workflow tools."
+))
+
+# After:
+mcp = FastMCP("jetsam", instructions=(
+    "jetsam is a git workflow accelerator. "
+    "Use workflow tools (status, save, sync, log, diff) for common operations. "
+    "Mutating tools (save, sync) return plans that must be confirmed with confirm(). "
+    "Use the git tool for any git operation not covered by workflow tools. "
+    "Error responses always contain 'error' and 'message' keys. "
+    "Check if 'error' in response to detect errors."
+))
+```
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `pytest tests/ -v`
+Expected: All tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/jetsam/mcp/server.py
+git commit -m "docs(mcp): document error contract in server instruction string"
+```

--- a/docs/superpowers/specs/2026-03-22-standardize-mcp-errors-design.md
+++ b/docs/superpowers/specs/2026-03-22-standardize-mcp-errors-design.md
@@ -1,0 +1,143 @@
+# P6-002: Standardize MCP Error Returns — Design Spec
+
+## Problem
+
+MCP tools return errors in at least four different formats (list-wrapped dicts,
+plain dicts, ad-hoc dicts, `JetsamError`), forcing agents to handle error
+detection differently per tool.
+
+## Approach
+
+**Approach C: JetsamError dict for expected errors + exception propagation for
+unexpected failures.**
+
+- Expected/recoverable errors (no platform, no PR, bad git ref) return
+  `JetsamError.to_dict()` — a dict with `error`, `message`, `recoverable`,
+  and optionally `suggested_action`.
+- Unexpected failures (platform crashes, network errors) propagate as
+  exceptions, caught by FastMCP and surfaced via MCP protocol `isError=True`.
+
+### Why this approach
+
+- Structured data for expected errors lets agents act programmatically (e.g.
+  branch on `error == "no_pr"` vs `error == "no_platform"`).
+- MCP `isError` alone only provides plain text — no machine-readable codes.
+- Exception propagation for unexpected failures is the correct semantic — agents
+  can't recover from those anyway.
+
+## Error Contract
+
+All expected error responses use `JetsamError.to_dict()`:
+
+```python
+{
+    "error": "<error_code>",       # machine-readable, always present
+    "message": "<human-readable>", # always present
+    "recoverable": True|False,     # always present
+    "suggested_action": "..."      # optional, only present when provided
+}
+```
+
+Note: `JetsamError.to_dict()` omits `suggested_action` when it is `None`,
+so not all error dicts will have this key.
+
+Agents detect errors via:
+- Dict-returning tools: `if "error" in response`
+- List-returning tools: `if isinstance(response, dict) and "error" in response`
+  (success returns a list, error returns a dict)
+
+### Standard Error Codes
+
+| Code | Meaning |
+|---|---|
+| `no_platform` | No GitHub/GitLab remote configured |
+| `no_pr` | No PR found for the given branch |
+| `git_error` | A git command failed |
+| `plan_not_found` | Plan ID is invalid or expired |
+
+## Tool Changes
+
+### Dict-returning tools — replace ad-hoc dicts with JetsamError
+
+| Tool | Error Code | Message |
+|---|---|---|
+| `diff()` (stat mode) | `git_error` | stderr from git |
+| `diff()` (full mode) | `git_error` | stderr from git (when `result.ok` is False) |
+| `pr_view()` | `no_platform` | "No platform configured" |
+| `pr_comment()` | `no_platform` / `no_pr` | contextual |
+| `pr_review()` | `no_platform` / `no_pr` | contextual |
+| `issue_close()` | `no_platform` | "No platform configured" |
+
+### List-returning tools — return JetsamError dict instead of list-wrapped error
+
+| Tool | Error Code(s) | Current Return | New Return |
+|---|---|---|---|
+| `log()` | `git_error` | `[{"error": ...}]` | `JetsamError.to_dict()` |
+| `pr_list()` | `no_platform` | `[{"error": ...}]` | `JetsamError.to_dict()` |
+| `checks()` | `no_platform`, `no_pr` | `[{"error": ...}]` | `JetsamError.to_dict()` |
+| `issues()` | `no_platform` | `[{"error": ...}]` | `JetsamError.to_dict()` |
+| `pr_comments()` | `no_platform`, `no_pr` | `[{"error": ...}]` | `JetsamError.to_dict()` |
+
+### No changes needed
+
+- `show_plan()`, `modify_plan()`, `confirm()` — already use `JetsamError`.
+- `status()`, `save()`, `sync()`, `ship()`, `switch()`, `start()`, `finish()`,
+  `tidy()`, `release()` — plan-returning/state tools. Errors propagate as
+  exceptions (consistent with the exception-propagation strategy for unexpected
+  failures).
+- `cancel()` — no error path (silently succeeds if plan ID is missing).
+
+### Intentionally excluded
+
+- `git()` — raw pass-through tool. Returns `{"ok", "stdout", "stderr",
+  "returncode"}` by design. Agents using this tool expect raw git output, not
+  structured JetsamError responses.
+
+## Helper Function
+
+Introduce a module-level helper in `tools.py` to reduce repetition for the
+common `no_platform` case:
+
+```python
+def _no_platform_error() -> dict[str, Any]:
+    return JetsamError(
+        error="no_platform",
+        message="No platform configured.",
+        suggested_action="Configure a GitHub or GitLab remote.",
+        recoverable=False,
+    ).to_dict()
+```
+
+Similarly for `no_pr`:
+
+```python
+def _no_pr_error(branch: str) -> dict[str, Any]:
+    return JetsamError(
+        error="no_pr",
+        message=f"No PR found for branch '{branch}'.",
+        recoverable=True,
+    ).to_dict()
+```
+
+## MCP Server Instruction Update
+
+Add to the `instructions` string in `server.py`:
+
+```
+"Error responses always contain 'error' and 'message' keys. "
+"Check if 'error' in response to detect errors."
+```
+
+## Tests
+
+Add/update tests in `test_mcp_tools.py` verifying:
+
+- Each error path returns a dict (not a list) with `error` and `message` keys
+- `recoverable` is always present in error responses
+- Error codes match the standard set
+- List-returning tools return a dict on error, a list on success
+
+## Scope
+
+~30-40 lines changed in `tools.py`, ~5 lines in `server.py`, ~10 new/updated
+tests. No changes to `JetsamError` itself or the platform layer.

--- a/src/jetsam/mcp/server.py
+++ b/src/jetsam/mcp/server.py
@@ -10,7 +10,9 @@ mcp = FastMCP("jetsam", instructions=(
     "jetsam is a git workflow accelerator. "
     "Use workflow tools (status, save, sync, log, diff) for common operations. "
     "Mutating tools (save, sync) return plans that must be confirmed with confirm(). "
-    "Use the git tool for any git operation not covered by workflow tools."
+    "Use the git tool for any git operation not covered by workflow tools. "
+    "All errors are returned as {error, message, recoverable} dicts. "
+    "Check for the 'error' key to detect failures."
 ))
 
 register_tools(mcp)

--- a/src/jetsam/mcp/tools.py
+++ b/src/jetsam/mcp/tools.py
@@ -167,7 +167,11 @@ def register_tools(mcp: FastMCP) -> None:
 
         result = run_git_sync(args)
         if not result.ok:
-            return [{"error": result.stderr.strip()}]
+            return JetsamError(
+                error="git_error",
+                message=result.stderr.strip(),
+                recoverable=True,
+            ).to_dict()
 
         entries = parse_log(result.stdout)
         return [asdict(e) for e in entries]
@@ -194,7 +198,11 @@ def register_tools(mcp: FastMCP) -> None:
 
             result = run_git_sync(args)
             if not result.ok:
-                return {"error": result.stderr.strip()}
+                return JetsamError(
+                    error="git_error",
+                    message=result.stderr.strip(),
+                    recoverable=True,
+                ).to_dict()
 
             parsed = parse_diff_numstat(result.stdout)
             return asdict(parsed)
@@ -206,6 +214,12 @@ def register_tools(mcp: FastMCP) -> None:
                 args.append(target)
 
             result = run_git_sync(args)
+            if not result.ok:
+                return JetsamError(
+                    error="git_error",
+                    message=result.stderr.strip(),
+                    recoverable=True,
+                ).to_dict()
             return {"diff": result.stdout, "ok": result.ok}
 
     @mcp.tool()

--- a/src/jetsam/mcp/tools.py
+++ b/src/jetsam/mcp/tools.py
@@ -247,7 +247,7 @@ def register_tools(mcp: FastMCP) -> None:
         actual_branch = branch or state.branch
         platform = _get_platform(state)
         if platform is None:
-            return {"error": "no_platform", "message": "No platform configured"}
+            return _no_platform_error()
         pr = platform.pr_for_branch(actual_branch)
         if pr is None:
             return {"pr": None, "branch": actual_branch}
@@ -267,7 +267,7 @@ def register_tools(mcp: FastMCP) -> None:
         repo_state = build_state()
         platform = _get_platform(repo_state)
         if platform is None:
-            return [{"error": "no_platform"}]
+            return _no_platform_error()
         prs = platform.pr_list(state=state, author=author)
         return [asdict(p) for p in prs]
 
@@ -281,13 +281,13 @@ def register_tools(mcp: FastMCP) -> None:
         repo_state = build_state()
         platform = _get_platform(repo_state)
         if platform is None:
-            return [{"error": "no_platform"}]
+            return _no_platform_error()
 
         actual_pr = pr_number
         if actual_pr is None:
             pr = platform.pr_for_branch(repo_state.branch)
             if pr is None:
-                return [{"error": "no_pr", "branch": repo_state.branch}]
+                return _no_pr_error(repo_state.branch)
             actual_pr = pr.number
 
         results = platform.pr_checks(actual_pr)
@@ -381,7 +381,7 @@ def register_tools(mcp: FastMCP) -> None:
         repo_state = build_state()
         platform = _get_platform(repo_state)
         if platform is None:
-            return [{"error": "no_platform"}]
+            return _no_platform_error()
         issue_list = platform.issue_list(state=state, labels=labels)
         return [asdict(i) for i in issue_list]
 
@@ -401,14 +401,14 @@ def register_tools(mcp: FastMCP) -> None:
         repo_state = build_state()
         platform = _get_platform(repo_state)
         if platform is None:
-            return {"error": "no_platform", "message": "No platform configured"}
+            return _no_platform_error()
 
         actual_pr = pr_number
         if actual_pr is None:
             actual_branch = branch or repo_state.branch
             pr = platform.pr_for_branch(actual_branch)
             if pr is None:
-                return {"error": "no_pr", "branch": actual_branch}
+                return _no_pr_error(actual_branch)
             actual_pr = pr.number
 
         return platform.pr_comment(actual_pr, body)
@@ -431,14 +431,14 @@ def register_tools(mcp: FastMCP) -> None:
         repo_state = build_state()
         platform = _get_platform(repo_state)
         if platform is None:
-            return {"error": "no_platform", "message": "No platform configured"}
+            return _no_platform_error()
 
         actual_pr = pr_number
         if actual_pr is None:
             actual_branch = branch or repo_state.branch
             pr = platform.pr_for_branch(actual_branch)
             if pr is None:
-                return {"error": "no_pr", "branch": actual_branch}
+                return _no_pr_error(actual_branch)
             actual_pr = pr.number
 
         return platform.pr_review(actual_pr, body, event)
@@ -457,14 +457,14 @@ def register_tools(mcp: FastMCP) -> None:
         repo_state = build_state()
         platform = _get_platform(repo_state)
         if platform is None:
-            return [{"error": "no_platform"}]
+            return _no_platform_error()
 
         actual_pr = pr_number
         if actual_pr is None:
             actual_branch = branch or repo_state.branch
             pr = platform.pr_for_branch(actual_branch)
             if pr is None:
-                return [{"error": "no_pr", "branch": actual_branch}]
+                return _no_pr_error(actual_branch)
             actual_pr = pr.number
 
         return platform.pr_comments(actual_pr)
@@ -485,7 +485,7 @@ def register_tools(mcp: FastMCP) -> None:
         repo_state = build_state()
         platform = _get_platform(repo_state)
         if platform is None:
-            return {"error": "no_platform", "message": "No platform configured"}
+            return _no_platform_error()
 
         return platform.issue_close(number, comment=comment, reason=reason)
 

--- a/src/jetsam/mcp/tools.py
+++ b/src/jetsam/mcp/tools.py
@@ -45,6 +45,25 @@ def _get_store() -> PlanStore:
     return _plan_store
 
 
+def _no_platform_error() -> dict[str, Any]:
+    """Standard error for missing platform configuration."""
+    return JetsamError(
+        error="no_platform",
+        message="No platform configured.",
+        suggested_action="Configure a GitHub or GitLab remote.",
+        recoverable=False,
+    ).to_dict()
+
+
+def _no_pr_error(branch: str) -> dict[str, Any]:
+    """Standard error for missing PR."""
+    return JetsamError(
+        error="no_pr",
+        message=f"No PR found for branch '{branch}'.",
+        recoverable=True,
+    ).to_dict()
+
+
 def register_tools(mcp: FastMCP) -> None:
     """Register all jetsam tools with the MCP server."""
 

--- a/src/jetsam/mcp/tools.py
+++ b/src/jetsam/mcp/tools.py
@@ -153,7 +153,7 @@ def register_tools(mcp: FastMCP) -> None:
         return plan.to_dict()
 
     @mcp.tool()
-    def log(n: int = 10, branch: str | None = None) -> list[dict[str, Any]]:
+    def log(n: int = 10, branch: str | None = None) -> list[dict[str, Any]] | dict[str, Any]:
         """Condensed commit history.
 
         Args:
@@ -257,7 +257,7 @@ def register_tools(mcp: FastMCP) -> None:
     def pr_list(
         state: str = "open",
         author: str | None = None,
-    ) -> list[dict[str, Any]]:
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """List pull requests.
 
         Args:
@@ -272,7 +272,7 @@ def register_tools(mcp: FastMCP) -> None:
         return [asdict(p) for p in prs]
 
     @mcp.tool()
-    def checks(pr_number: int | None = None) -> list[dict[str, Any]]:
+    def checks(pr_number: int | None = None) -> list[dict[str, Any]] | dict[str, Any]:
         """CI check status for current branch or a specific PR.
 
         Args:
@@ -371,7 +371,7 @@ def register_tools(mcp: FastMCP) -> None:
     def issues(
         state: str = "open",
         labels: list[str] | None = None,
-    ) -> list[dict[str, Any]]:
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """List issues from the project tracker.
 
         Args:
@@ -447,7 +447,7 @@ def register_tools(mcp: FastMCP) -> None:
     def pr_comments(
         branch: str | None = None,
         pr_number: int | None = None,
-    ) -> list[dict[str, Any]]:
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         """Read comments and reviews on a pull request.
 
         Args:

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -214,6 +214,70 @@ class TestNewToolsRegistration:
         assert "issue_close" in tool_names
 
 
+class TestErrorFormats:
+    """Verify all error paths return standard JetsamError dicts."""
+
+    def test_log_error_returns_jetsam_error_dict(
+        self, tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """log() should return a JetsamError dict, not a list, on error."""
+        monkeypatch.setenv("GIT_DIR", str(tmp_git_repo / ".git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(tmp_git_repo))
+
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        mcp_tools.register_tools(mcp)
+
+        log_fn = mcp._tool_manager._tools["log"].fn
+        result = log_fn(n=10, branch="nonexistent-branch-xyz")
+
+        assert isinstance(result, dict), "Error should be a dict, not a list"
+        assert result["error"] == "git_error"
+        assert "message" in result
+        assert "recoverable" in result
+
+    def test_diff_stat_error_returns_jetsam_error_dict(
+        self, tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """diff() in stat mode should return JetsamError dict on error."""
+        monkeypatch.setenv("GIT_DIR", str(tmp_git_repo / ".git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(tmp_git_repo))
+
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        mcp_tools.register_tools(mcp)
+
+        diff_fn = mcp._tool_manager._tools["diff"].fn
+        result = diff_fn(target="nonexistent-ref-xyz", stat=True, staged=False)
+
+        assert isinstance(result, dict)
+        assert result["error"] == "git_error"
+        assert "message" in result
+        assert "recoverable" in result
+
+    def test_diff_full_error_returns_jetsam_error_dict(
+        self, tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """diff() in full mode should return JetsamError dict on error."""
+        monkeypatch.setenv("GIT_DIR", str(tmp_git_repo / ".git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(tmp_git_repo))
+
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        mcp_tools.register_tools(mcp)
+
+        diff_fn = mcp._tool_manager._tools["diff"].fn
+        result = diff_fn(target="nonexistent-ref-xyz", stat=False, staged=False)
+
+        assert isinstance(result, dict)
+        assert result["error"] == "git_error"
+        assert "message" in result
+        assert "recoverable" in result
+
+
 class TestErrorHelpers:
     """Test the error helper functions produce standard JetsamError format."""
 

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -212,3 +212,23 @@ class TestNewToolsRegistration:
         assert "pr_review" in tool_names
         assert "pr_comments" in tool_names
         assert "issue_close" in tool_names
+
+
+class TestErrorHelpers:
+    """Test the error helper functions produce standard JetsamError format."""
+
+    def test_no_platform_error(self):
+        from jetsam.mcp.tools import _no_platform_error
+
+        result = _no_platform_error()
+        assert result["error"] == "no_platform"
+        assert "message" in result
+        assert result["recoverable"] is False
+
+    def test_no_pr_error(self):
+        from jetsam.mcp.tools import _no_pr_error
+
+        result = _no_pr_error("feature/foo")
+        assert result["error"] == "no_pr"
+        assert "feature/foo" in result["message"]
+        assert result["recoverable"] is True

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -278,6 +278,171 @@ class TestErrorFormats:
         assert "recoverable" in result
 
 
+    def test_pr_view_no_platform_returns_jetsam_error(
+        self, tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("GIT_DIR", str(tmp_git_repo / ".git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(tmp_git_repo))
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        mcp_tools.register_tools(mcp)
+
+        pr_view_fn = mcp._tool_manager._tools["pr_view"].fn
+        result = pr_view_fn(branch=None)
+
+        assert isinstance(result, dict)
+        assert result["error"] == "no_platform"
+        assert "message" in result
+        assert "recoverable" in result
+
+    def test_pr_list_no_platform_returns_jetsam_error_dict(
+        self, tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("GIT_DIR", str(tmp_git_repo / ".git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(tmp_git_repo))
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        mcp_tools.register_tools(mcp)
+
+        pr_list_fn = mcp._tool_manager._tools["pr_list"].fn
+        result = pr_list_fn(state="open", author=None)
+
+        assert isinstance(result, dict), "Error should be a dict, not a list"
+        assert result["error"] == "no_platform"
+        assert "message" in result
+        assert "recoverable" in result
+
+    def test_checks_no_platform_returns_jetsam_error_dict(
+        self, tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("GIT_DIR", str(tmp_git_repo / ".git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(tmp_git_repo))
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        mcp_tools.register_tools(mcp)
+
+        checks_fn = mcp._tool_manager._tools["checks"].fn
+        result = checks_fn(pr_number=None)
+
+        assert isinstance(result, dict), "Error should be a dict, not a list"
+        assert result["error"] == "no_platform"
+        assert "message" in result
+
+    def test_issues_no_platform_returns_jetsam_error_dict(
+        self, tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("GIT_DIR", str(tmp_git_repo / ".git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(tmp_git_repo))
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        mcp_tools.register_tools(mcp)
+
+        issues_fn = mcp._tool_manager._tools["issues"].fn
+        result = issues_fn(state="open", labels=None)
+
+        assert isinstance(result, dict), "Error should be a dict, not a list"
+        assert result["error"] == "no_platform"
+        assert "message" in result
+
+    def test_pr_comments_no_platform_returns_jetsam_error_dict(
+        self, tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("GIT_DIR", str(tmp_git_repo / ".git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(tmp_git_repo))
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        mcp_tools.register_tools(mcp)
+
+        fn = mcp._tool_manager._tools["pr_comments"].fn
+        result = fn(branch=None, pr_number=None)
+
+        assert isinstance(result, dict), "Error should be a dict, not a list"
+        assert result["error"] == "no_platform"
+        assert "message" in result
+
+    def test_pr_comment_no_platform_returns_jetsam_error(
+        self, tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("GIT_DIR", str(tmp_git_repo / ".git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(tmp_git_repo))
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        mcp_tools.register_tools(mcp)
+
+        fn = mcp._tool_manager._tools["pr_comment"].fn
+        result = fn(body="test", branch=None, pr_number=None)
+
+        assert isinstance(result, dict)
+        assert result["error"] == "no_platform"
+        assert "message" in result
+
+    def test_pr_review_no_platform_returns_jetsam_error(
+        self, tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("GIT_DIR", str(tmp_git_repo / ".git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(tmp_git_repo))
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        mcp_tools.register_tools(mcp)
+
+        fn = mcp._tool_manager._tools["pr_review"].fn
+        result = fn(event="approve", body="", branch=None, pr_number=None)
+
+        assert isinstance(result, dict)
+        assert result["error"] == "no_platform"
+        assert "message" in result
+
+    def test_issue_close_no_platform_returns_jetsam_error(
+        self, tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("GIT_DIR", str(tmp_git_repo / ".git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(tmp_git_repo))
+        from mcp.server.fastmcp import FastMCP
+
+        mcp = FastMCP("test")
+        mcp_tools.register_tools(mcp)
+
+        fn = mcp._tool_manager._tools["issue_close"].fn
+        result = fn(number=999, comment=None, reason="completed")
+
+        assert isinstance(result, dict)
+        assert result["error"] == "no_platform"
+        assert "message" in result
+
+    def test_checks_no_pr_returns_jetsam_error_dict(
+        self, tmp_git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """checks() should return JetsamError dict when no PR exists."""
+        monkeypatch.setenv("GIT_DIR", str(tmp_git_repo / ".git"))
+        monkeypatch.setenv("GIT_WORK_TREE", str(tmp_git_repo))
+
+        from unittest.mock import MagicMock
+
+        from mcp.server.fastmcp import FastMCP
+
+        mock_platform = MagicMock()
+        mock_platform.pr_for_branch.return_value = None
+        monkeypatch.setattr(mcp_tools, "_get_platform", lambda _: mock_platform)
+
+        mcp = FastMCP("test")
+        mcp_tools.register_tools(mcp)
+
+        checks_fn = mcp._tool_manager._tools["checks"].fn
+        result = checks_fn(pr_number=None)
+
+        assert isinstance(result, dict), "Error should be a dict, not a list"
+        assert result["error"] == "no_pr"
+        assert "message" in result
+        assert "recoverable" in result
+
+
 class TestErrorHelpers:
     """Test the error helper functions produce standard JetsamError format."""
 


### PR DESCRIPTION
## Summary

- Add `_no_platform_error()` and `_no_pr_error()` helpers returning standard `JetsamError.to_dict()` format
- Replace all ad-hoc error dicts/lists across 8 MCP tools with standardized helpers
- Standardize `log()` and `diff()` error returns to use `JetsamError`
- All errors now return `{error, message, recoverable}` dicts — agents can check `if "error" in response`
- Document error contract in MCP server instruction string

## Test plan
- [x] 24 MCP tool tests pass including new error format assertions
- [x] Error helpers produce correct JetsamError format
- [x] Tools that previously returned `[{"error": ...}]` lists now return dicts
- [ ] Manual: call `pr_view()` in a repo with no platform, verify error format

🤖 Generated with [Claude Code](https://claude.com/claude-code)