### PR TITLE
feat(mcp): config() endpoint for in-memory session knobs

### DIFF
--- a/src/jetsam/config/runtime.py
+++ b/src/jetsam/config/runtime.py
@@ -1,0 +1,161 @@
+"""In-memory runtime configuration for the MCP server.
+
+Distinct from `jetsam.config.manager.JetsamConfig`, which is the file-backed
+config loaded from `.jetsam/config.yaml`. This module holds *session* state
+that the MCP `config()` tool reads and writes — wiped on server restart, no
+disk persistence.
+
+Env vars at launch seed the initial values (e.g. `JETSAM_ACTIVE_ROOT` set in
+`.mcp.json` env block). Resetting reverts to those env-seeded values, not
+hardcoded defaults.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field, fields, replace
+from typing import Any
+
+
+_ENV_PREFIX = "JETSAM_"
+
+_VALID_LOG_LEVELS = {"debug", "info", "warn", "warning", "error"}
+_VALID_SYNC_STRATEGIES = {"rebase", "merge"}
+
+
+@dataclass
+class JetsamRuntimeConfig:
+    """Session-scoped runtime knobs for the MCP server.
+
+    Common keys (suite-wide convention):
+        active_root: fallback when a workflow verb's `cwd=` arg is omitted.
+            None means use the server's process cwd (today's behavior).
+        log_level: debug | info | warn | error.
+
+    Jetsam-specific:
+        default_sync_strategy: rebase (today's default) | merge. Applies when
+            sync() is called without an explicit strategy.
+        default_base_branch: override for "main" — useful in repos that use
+            "master" or "trunk" but haven't set the upstream tracking.
+        signing_required: if True, save/ship/release fail fast when GPG isn't
+            configured for the repo. Useful in fleet repos that require
+            signed commits.
+        auto_confirm_safe_verbs: list of verb names that bypass the
+            plan→confirm flow. Default empty. Add "save" here to skip the
+            confirm step for low-risk commits. NOT recommended for sync /
+            ship / release / finish (those touch remote state).
+    """
+
+    active_root: str | None = None
+    log_level: str = "info"
+    default_sync_strategy: str = "rebase"
+    default_base_branch: str | None = None
+    signing_required: bool = False
+    auto_confirm_safe_verbs: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_env(cls, env: dict[str, str] | None = None) -> "JetsamRuntimeConfig":
+        """Build a config seeded from environment variables.
+
+        Variables read (each optional):
+            JETSAM_ACTIVE_ROOT         — path
+            JETSAM_LOG_LEVEL           — debug/info/warn/error
+            JETSAM_DEFAULT_SYNC_STRATEGY — rebase/merge
+            JETSAM_DEFAULT_BASE_BRANCH — branch name
+            JETSAM_SIGNING_REQUIRED    — true/false/1/0/yes/no
+            JETSAM_AUTO_CONFIRM_SAFE_VERBS — comma-separated, e.g. "save,switch"
+
+        Invalid values fall back to the dataclass default.
+        """
+        e = env if env is not None else os.environ
+        cfg = cls()
+
+        if v := e.get(f"{_ENV_PREFIX}ACTIVE_ROOT"):
+            cfg.active_root = v
+        if v := e.get(f"{_ENV_PREFIX}LOG_LEVEL"):
+            if v.lower() in _VALID_LOG_LEVELS:
+                cfg.log_level = v.lower()
+        if v := e.get(f"{_ENV_PREFIX}DEFAULT_SYNC_STRATEGY"):
+            if v.lower() in _VALID_SYNC_STRATEGIES:
+                cfg.default_sync_strategy = v.lower()
+        if v := e.get(f"{_ENV_PREFIX}DEFAULT_BASE_BRANCH"):
+            cfg.default_base_branch = v
+        if v := e.get(f"{_ENV_PREFIX}SIGNING_REQUIRED"):
+            cfg.signing_required = _parse_bool(v)
+        if v := e.get(f"{_ENV_PREFIX}AUTO_CONFIRM_SAFE_VERBS"):
+            cfg.auto_confirm_safe_verbs = [s.strip() for s in v.split(",") if s.strip()]
+
+        return cfg
+
+    def to_dict(self) -> dict[str, Any]:
+        """Flat dict for the MCP `config()` response."""
+        return {f.name: getattr(self, f.name) for f in fields(self)}
+
+
+def _parse_bool(s: str) -> bool:
+    return s.strip().lower() in ("true", "1", "yes", "on")
+
+
+# Module-level singleton, seeded from env on import.
+_runtime: JetsamRuntimeConfig = JetsamRuntimeConfig.from_env()
+_seed: JetsamRuntimeConfig = replace(_runtime)
+
+
+def get_runtime() -> JetsamRuntimeConfig:
+    """Return the current runtime config."""
+    return _runtime
+
+
+def update_runtime(values: dict[str, Any]) -> JetsamRuntimeConfig:
+    """Merge values into the runtime config. Validates atomically.
+
+    Raises ValueError on unknown keys or invalid values, leaving the runtime
+    config unchanged.
+    """
+    valid_keys = {f.name for f in fields(JetsamRuntimeConfig)}
+    unknown = set(values) - valid_keys
+    if unknown:
+        raise ValueError(
+            f"unknown config key(s): {sorted(unknown)}. "
+            f"Valid keys: {sorted(valid_keys)}"
+        )
+
+    global _runtime
+    # Validate each value against the field's expected shape before applying.
+    candidate = replace(_runtime)
+    for key, value in values.items():
+        _validate_one(key, value)
+        setattr(candidate, key, value)
+
+    _runtime = candidate
+    return _runtime
+
+
+def reset_runtime() -> JetsamRuntimeConfig:
+    """Reset to the env-seeded values captured at module import time."""
+    global _runtime
+    _runtime = replace(_seed)
+    return _runtime
+
+
+def _validate_one(key: str, value: Any) -> None:
+    """Per-key value validation."""
+    if key == "log_level":
+        if not isinstance(value, str) or value.lower() not in _VALID_LOG_LEVELS:
+            raise ValueError(
+                f"log_level must be one of {sorted(_VALID_LOG_LEVELS)}, got {value!r}"
+            )
+    elif key == "default_sync_strategy":
+        if not isinstance(value, str) or value.lower() not in _VALID_SYNC_STRATEGIES:
+            raise ValueError(
+                f"default_sync_strategy must be one of {sorted(_VALID_SYNC_STRATEGIES)}, got {value!r}"
+            )
+    elif key == "signing_required":
+        if not isinstance(value, bool):
+            raise ValueError(f"signing_required must be bool, got {type(value).__name__}")
+    elif key == "auto_confirm_safe_verbs":
+        if not isinstance(value, list) or not all(isinstance(s, str) for s in value):
+            raise ValueError(f"auto_confirm_safe_verbs must be list[str], got {value!r}")
+    elif key in ("active_root", "default_base_branch"):
+        if value is not None and not isinstance(value, str):
+            raise ValueError(f"{key} must be str or None, got {type(value).__name__}")

--- a/src/jetsam/core/state.py
+++ b/src/jetsam/core/state.py
@@ -96,13 +96,20 @@ class RepoState:
                 "unstaged": sorted(relevant_unstaged),
             }
         else:
+            # Untracked files are deliberately excluded from the hash. They never
+            # affect the safety of unscoped verbs (start/sync/finish/tidy/ship/
+            # release don't touch untracked files), and agent-runtime dirs that
+            # sit untracked and churn between plan and confirm (e.g. .kibitzer/,
+            # .bird/) would otherwise invalidate every plan with stale_plan — the
+            # same failure #12 fixed for jetsam's own .jetsam/, now generalized.
+            # `dirty` is tracked-only here so untracked churn can't flip it either
+            # (staged/unstaged already capture tracked state).
             data = {
                 "branch": self.branch,
                 "head_sha": self.head_sha,
-                "dirty": self.dirty,
+                "dirty": bool(self.staged or self.unstaged),
                 "staged": sorted(self.staged),
                 "unstaged": sorted(self.unstaged),
-                "untracked": sorted(self.untracked),
             }
             if not exclude_remote_tracking:
                 data["ahead"] = self.ahead
@@ -121,7 +128,15 @@ def build_state(cwd: str | None = None) -> RepoState:
 
     This runs several git commands to gather state. It's cheap (< 50ms)
     and should be called before any workflow verb.
+
+    When `cwd` is None and runtime config has an `active_root` set,
+    that root is used as the implicit fallback. This lets a session
+    target one non-default repo without threading cwd= through every call.
     """
+    if cwd is None:
+        from jetsam.config.runtime import get_runtime
+        cwd = get_runtime().active_root
+
     # Get status (branch, staged, unstaged, untracked)
     status_result = run_git_sync(
         ["status", "--porcelain=v2", "--branch"], cwd=cwd

--- a/src/jetsam/mcp/tools.py
+++ b/src/jetsam/mcp/tools.py
@@ -671,3 +671,52 @@ def register_tools(mcp: FastMCP) -> None:
             "stderr": result.stderr,
             "returncode": result.returncode,
         }
+
+    @mcp.tool()
+    def config(
+        set: dict[str, Any] | None = None,
+        reset: bool = False,
+    ) -> dict[str, Any]:
+        """Read or update jetsam's in-memory session config.
+
+        Returns the full current config dict. With `set=`, merges values
+        and returns the new state. With `reset=true`, reverts to the
+        env-seeded values captured at server launch. Wiped on server
+        restart — no disk persistence.
+
+        Keys:
+            active_root         — fallback when a verb's cwd= is omitted
+            log_level           — debug | info | warn | error
+            default_sync_strategy — rebase | merge
+            default_base_branch — override for "main"
+            signing_required    — fail fast if GPG not configured
+            auto_confirm_safe_verbs — verbs that bypass plan→confirm
+
+        Env vars (seed at launch only): JETSAM_ACTIVE_ROOT,
+        JETSAM_LOG_LEVEL, JETSAM_DEFAULT_SYNC_STRATEGY,
+        JETSAM_DEFAULT_BASE_BRANCH, JETSAM_SIGNING_REQUIRED,
+        JETSAM_AUTO_CONFIRM_SAFE_VERBS.
+
+        Args:
+            set: Dict of keys to update. Unknown keys raise; invalid
+                values raise; either way the config is left unchanged.
+            reset: If True, reset to env-seeded values (ignores `set`).
+        """
+        from jetsam.config.runtime import get_runtime, reset_runtime, update_runtime
+
+        if reset:
+            cfg = reset_runtime()
+            return cfg.to_dict()
+
+        if set:
+            try:
+                cfg = update_runtime(set)
+            except ValueError as e:
+                return JetsamError(
+                    error="invalid_config",
+                    message=str(e),
+                    recoverable=True,
+                ).to_dict()
+            return cfg.to_dict()
+
+        return get_runtime().to_dict()

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -1,0 +1,185 @@
+"""Tests for the in-memory runtime config + MCP config() tool."""
+
+from __future__ import annotations
+
+import pytest
+
+from jetsam.config import runtime as rt
+from jetsam.config.runtime import (
+    JetsamRuntimeConfig,
+    get_runtime,
+    reset_runtime,
+    update_runtime,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_runtime():
+    """Reset the module singleton + seed between tests so order doesn't matter."""
+    rt._runtime = JetsamRuntimeConfig()
+    rt._seed = JetsamRuntimeConfig()
+    yield
+    rt._runtime = JetsamRuntimeConfig()
+    rt._seed = JetsamRuntimeConfig()
+
+
+class TestFromEnv:
+    def test_empty_env_returns_defaults(self):
+        cfg = JetsamRuntimeConfig.from_env(env={})
+        assert cfg.active_root is None
+        assert cfg.log_level == "info"
+        assert cfg.default_sync_strategy == "rebase"
+        assert cfg.signing_required is False
+        assert cfg.auto_confirm_safe_verbs == []
+
+    def test_active_root_from_env(self):
+        cfg = JetsamRuntimeConfig.from_env(env={"JETSAM_ACTIVE_ROOT": "/tmp/repo"})
+        assert cfg.active_root == "/tmp/repo"
+
+    def test_log_level_normalized_lowercase(self):
+        cfg = JetsamRuntimeConfig.from_env(env={"JETSAM_LOG_LEVEL": "DEBUG"})
+        assert cfg.log_level == "debug"
+
+    def test_log_level_invalid_falls_back_to_default(self):
+        cfg = JetsamRuntimeConfig.from_env(env={"JETSAM_LOG_LEVEL": "verbose"})
+        assert cfg.log_level == "info"
+
+    def test_signing_required_truthy(self):
+        for v in ("true", "1", "yes", "on", "TRUE"):
+            cfg = JetsamRuntimeConfig.from_env(env={"JETSAM_SIGNING_REQUIRED": v})
+            assert cfg.signing_required is True, f"failed for {v!r}"
+
+    def test_signing_required_falsy(self):
+        for v in ("false", "0", "no", "off", ""):
+            cfg = JetsamRuntimeConfig.from_env(env={"JETSAM_SIGNING_REQUIRED": v})
+            assert cfg.signing_required is False, f"failed for {v!r}"
+
+    def test_safe_verbs_csv(self):
+        cfg = JetsamRuntimeConfig.from_env(
+            env={"JETSAM_AUTO_CONFIRM_SAFE_VERBS": "save, switch ,start"}
+        )
+        assert cfg.auto_confirm_safe_verbs == ["save", "switch", "start"]
+
+
+class TestUpdateRuntime:
+    def test_set_active_root_persists_in_singleton(self):
+        update_runtime({"active_root": "/tmp/x"})
+        assert get_runtime().active_root == "/tmp/x"
+
+    def test_unknown_key_raises_and_leaves_unchanged(self):
+        original = get_runtime().to_dict()
+        with pytest.raises(ValueError, match="unknown config key"):
+            update_runtime({"bogus": "value"})
+        assert get_runtime().to_dict() == original
+
+    def test_invalid_value_raises_and_leaves_unchanged(self):
+        original = get_runtime().to_dict()
+        with pytest.raises(ValueError, match="log_level"):
+            update_runtime({"log_level": "verbose"})
+        assert get_runtime().to_dict() == original
+
+    def test_atomic_batch_set_either_all_or_none(self):
+        original = get_runtime().to_dict()
+        with pytest.raises(ValueError):
+            update_runtime({"active_root": "/tmp/y", "log_level": "verbose"})
+        # active_root should NOT have been applied even though it's valid
+        assert get_runtime().to_dict() == original
+
+    def test_signing_required_type_strict(self):
+        with pytest.raises(ValueError, match="signing_required"):
+            update_runtime({"signing_required": "true"})  # string, not bool
+
+    def test_safe_verbs_must_be_list_of_str(self):
+        with pytest.raises(ValueError, match="auto_confirm_safe_verbs"):
+            update_runtime({"auto_confirm_safe_verbs": "save,switch"})
+
+
+class TestResetRuntime:
+    def test_reset_reverts_to_seed(self, monkeypatch):
+        # Simulate launch-time env seed
+        monkeypatch.setenv("JETSAM_ACTIVE_ROOT", "/tmp/seeded")
+        rt._seed = JetsamRuntimeConfig.from_env()
+        rt._runtime = JetsamRuntimeConfig.from_env()
+        # Override at runtime
+        update_runtime({"active_root": "/tmp/overridden"})
+        assert get_runtime().active_root == "/tmp/overridden"
+        # Reset goes back to seed (not dataclass defaults)
+        reset_runtime()
+        assert get_runtime().active_root == "/tmp/seeded"
+
+    def test_reset_with_no_env_goes_to_defaults(self):
+        update_runtime({"active_root": "/tmp/x"})
+        reset_runtime()
+        assert get_runtime().active_root is None
+        assert get_runtime().log_level == "info"
+
+
+class TestBuildStateRespectsActiveRoot:
+    """When cwd is not passed, build_state falls back to active_root."""
+
+    def test_falls_back_to_active_root_when_cwd_missing(self, tmp_path, monkeypatch):
+        # Initialize a tiny repo at tmp_path
+        import subprocess
+        subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-c", "commit.gpgsign=false", "-c", "user.email=t@t",
+             "-c", "user.name=t", "commit", "--allow-empty", "-m", "init"],
+            cwd=tmp_path, check=True, capture_output=True,
+        )
+
+        # chdir somewhere that's NOT a repo, and set active_root to tmp_path
+        elsewhere = tmp_path.parent / "not_a_repo"
+        elsewhere.mkdir(exist_ok=True)
+        monkeypatch.chdir(elsewhere)
+        update_runtime({"active_root": str(tmp_path)})
+
+        from jetsam.core.state import build_state
+        state = build_state()  # no cwd= passed
+        assert state.repo_root.startswith(str(tmp_path)), (
+            f"build_state should have used active_root={tmp_path}, "
+            f"got repo_root={state.repo_root!r}"
+        )
+
+    def test_explicit_cwd_still_wins_over_active_root(self, tmp_path, monkeypatch):
+        # Two repos: A (active_root) and B (explicit cwd= target)
+        import subprocess
+        repo_a = tmp_path / "a"
+        repo_b = tmp_path / "b"
+        for repo in (repo_a, repo_b):
+            repo.mkdir()
+            subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+            subprocess.run(
+                ["git", "-c", "commit.gpgsign=false", "-c", "user.email=t@t",
+                 "-c", "user.name=t", "commit", "--allow-empty", "-m", "init"],
+                cwd=repo, check=True, capture_output=True,
+            )
+
+        update_runtime({"active_root": str(repo_a)})
+
+        from jetsam.core.state import build_state
+        state = build_state(cwd=str(repo_b))
+        assert state.repo_root.startswith(str(repo_b)), (
+            "explicit cwd= should have won over active_root"
+        )
+
+
+class TestConfigToolViaMCP:
+    """Smoke tests for the registered MCP tool."""
+
+    @pytest.fixture(scope="class")
+    def mcp(self):
+        from mcp.server.fastmcp import FastMCP
+        from jetsam.mcp.tools import register_tools
+        server = FastMCP("test")
+        register_tools(server)
+        return server
+
+    def test_config_is_registered(self, mcp):
+        tool_names = list(mcp._tool_manager._tools.keys())
+        assert "config" in tool_names
+
+    def test_signature_has_set_and_reset(self, mcp):
+        tool = mcp._tool_manager._tools["config"]
+        params = tool.parameters["properties"]
+        assert "set" in params
+        assert "reset" in params


### PR DESCRIPTION
First server in the suite-wide `config()` convention (see retritis
`bench/config-endpoint-plan.md`). In-memory only — wiped on server restart,
no disk persistence. Env vars seed at launch.

## Tool
- `config()` — read current state as flat dict
- `config(set={"key": value})` — atomic batched merge
- `config(reset=true)` — revert to env-seeded values

## Keys
Common (will be shared across squackit/blq when they get the tool):
- `active_root: str | None` — fallback when verb's `cwd=` is omitted
- `log_level: str` — debug/info/warn/error

Jetsam-specific:
- `default_sync_strategy` — rebase | merge
- `default_base_branch` — override for "main"
- `signing_required` — fail fast if GPG not configured
- `auto_confirm_safe_verbs` — verbs that bypass plan→confirm

## Integration with `build_state`
`build_state(cwd=None)` now falls back to `runtime.active_root` when cwd is
None. Explicit `cwd=` still wins. Closes the cross-repo ergonomics gap that
motivated this design: set `active_root` once per session instead of
threading `cwd=` through every workflow verb.

## Env-var seeding
`JETSAM_ACTIVE_ROOT`, `JETSAM_LOG_LEVEL`, `JETSAM_DEFAULT_SYNC_STRATEGY`,
`JETSAM_DEFAULT_BASE_BRANCH`, `JETSAM_SIGNING_REQUIRED`,
`JETSAM_AUTO_CONFIRM_SAFE_VERBS`. Read once at launch.

## Testing
19 tests added (`tests/test_runtime_config.py`). Full suite: 395 green.