### PR TITLE
fix(state): exclude untracked files from the unscoped plan hash (generalizes #12)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jetsam-mcp"
-version = "1.1.1"
+version = "1.1.2"
 description = "Git workflow accelerator for humans and agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/jetsam/__init__.py
+++ b/src/jetsam/__init__.py
@@ -1,3 +1,3 @@
 """jetsam — Git workflow accelerator for humans and agents."""
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"

--- a/src/jetsam/core/state.py
+++ b/src/jetsam/core/state.py
@@ -96,13 +96,20 @@ class RepoState:
                 "unstaged": sorted(relevant_unstaged),
             }
         else:
+            # Untracked files are deliberately excluded from the hash. They never
+            # affect the safety of unscoped verbs (start/sync/finish/tidy/ship/
+            # release don't touch untracked files), and agent-runtime dirs that
+            # sit untracked and churn between plan and confirm (e.g. .kibitzer/,
+            # .bird/) would otherwise invalidate every plan with stale_plan — the
+            # same failure #12 fixed for jetsam's own .jetsam/, now generalized.
+            # `dirty` is tracked-only here so untracked churn can't flip it either
+            # (staged/unstaged already capture tracked state).
             data = {
                 "branch": self.branch,
                 "head_sha": self.head_sha,
-                "dirty": self.dirty,
+                "dirty": bool(self.staged or self.unstaged),
                 "staged": sorted(self.staged),
                 "unstaged": sorted(self.unstaged),
-                "untracked": sorted(self.untracked),
             }
             if not exclude_remote_tracking:
                 data["ahead"] = self.ahead

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -34,8 +34,10 @@ class TestBuildState:
         state1 = build_state(cwd=str(tmp_git_repo))
         hash1 = state1.compute_hash()
 
-        # Create a new file
-        (tmp_git_repo / "new.py").write_text("new\n")
+        # Modify a TRACKED file — an unstaged change must change the hash.
+        # (A new *untracked* file deliberately does not; see
+        # test_unscoped_hash_stable_across_untracked_churn_e2e.)
+        (tmp_git_repo / "README.md").write_text("# Test\nmodified\n")
 
         state2 = build_state(cwd=str(tmp_git_repo))
         hash2 = state2.compute_hash()
@@ -100,6 +102,46 @@ class TestBuildState:
         plans.mkdir(parents=True)
         (plans / "p_abc.json").write_text('{"plan": 1}\n')
 
+        hash_after = build_state(cwd=str(tmp_git_repo)).compute_hash()
+        assert hash_before == hash_after
+
+    def test_unscoped_hash_ignores_untracked_churn(self):
+        """Untracked-file churn (agent-runtime dirs like .kibitzer/, .bird/) must
+        not change the unscoped hash — generalizes the #12 .jetsam/ fix so such
+        dirs don't cause stale_plan on start/sync."""
+        base = dict(
+            branch="feature", upstream="origin/feature", default_branch="main",
+            dirty=True, staged=[], unstaged=[], untracked=[".kibitzer/a"],
+            ahead=0, behind=0, stash_count=0,
+            platform="github", remote="user/repo",
+            remote_url="git@github.com:user/repo.git",
+            head_sha="abc123", repo_root="/tmp/repo",
+        )
+        s1 = RepoState(**base)
+        s2 = RepoState(**{**base, "untracked": [".kibitzer/a", ".bird/log", "scratch.txt"]})
+        assert s1.compute_hash() == s2.compute_hash()
+
+    def test_unscoped_hash_reflects_tracked_changes(self):
+        """Sanity: excluding untracked must not also drop tracked changes."""
+        base = dict(
+            branch="feature", upstream="origin/feature", default_branch="main",
+            dirty=False, staged=[], unstaged=[], untracked=[],
+            ahead=0, behind=0, stash_count=0,
+            platform="github", remote="user/repo",
+            remote_url="git@github.com:user/repo.git",
+            head_sha="abc123", repo_root="/tmp/repo",
+        )
+        s1 = RepoState(**base)
+        s2 = RepoState(**{**base, "staged": ["src/x.py"]})
+        assert s1.compute_hash() != s2.compute_hash()
+
+    def test_unscoped_hash_stable_across_untracked_churn_e2e(self, tmp_git_repo: Path):
+        """End-to-end: creating an arbitrary untracked dir must not change the
+        unscoped hash (the stale_plan-on-confirm bug for non-.jetsam dirs)."""
+        hash_before = build_state(cwd=str(tmp_git_repo)).compute_hash()
+        kb = tmp_git_repo / ".kibitzer"
+        kb.mkdir()
+        (kb / "session.json").write_text('{"a": 1}\n')
         hash_after = build_state(cwd=str(tmp_git_repo)).compute_hash()
         assert hash_before == hash_after
 


### PR DESCRIPTION
## Problem
`compute_hash` (unscoped) is built from `git status --porcelain` and counts **untracked** files. Agent-runtime dirs that sit untracked and churn between plan-creation and `confirm` — `.kibitzer/`, `.bird/`, etc. — change the untracked list and trip `stale_plan` on every unscoped verb (`start`, `sync`, ...). This is the same failure #12 fixed, but #12 only excluded jetsam's *own* `.jetsam/`. In practice agents hit this constantly and fall back to raw `git`, defeating the plan→confirm guard.

## Fix
Drop untracked files from the **unscoped** hash entirely, and compute its `dirty` tracked-only (`bool(staged or unstaged)`) so untracked churn can't flip it either. This is safe:
- unscoped verbs (start/sync/finish/tidy/ship/release) never touch untracked files;
- the **scoped** path (save/commit) already hashes only its scoped staged/unstaged files — untracked was never in it.

## Tests
- `test_unscoped_hash_ignores_untracked_churn` + `..._e2e` — untracked churn (incl. creating an arbitrary untracked dir) leaves the hash stable.
- `test_unscoped_hash_reflects_tracked_changes` — tracked changes still change it.
- Updated `test_state_hash_changes_on_modification` to mutate a *tracked* file (its old new-untracked-file assertion encoded the exact behavior this fixes).
- Full suite: **376 passed**.

Bumps 1.1.1 → 1.1.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)