### PR TITLE
feat(planner): consume sync_strategy + signing_required config knobs

### DIFF
--- a/src/jetsam/core/planner.py
+++ b/src/jetsam/core/planner.py
@@ -9,6 +9,31 @@ from typing import Any
 
 from jetsam.config.manager import JetsamConfig, load_config
 from jetsam.core.state import RepoState
+from jetsam.git.wrapper import run_git_sync
+
+
+def _signing_required_check(state: RepoState, op: str) -> list[str]:
+    """If runtime.signing_required is set, fail fast if gpg signing is off.
+
+    Returns a single warning string if signing is required but not
+    configured in the repo, else an empty list. Callers should refuse
+    to add any execution steps when this returns non-empty.
+    """
+    from jetsam.config.runtime import get_runtime
+    if not get_runtime().signing_required:
+        return []
+    result = run_git_sync(
+        ["config", "--get", "commit.gpgsign"], cwd=state.repo_root,
+    )
+    val = result.stdout.strip().lower() if result.ok else ""
+    if val in ("true", "1", "yes"):
+        return []
+    return [
+        f"Refusing to plan {op}: runtime config signing_required is set, "
+        f"but commit.gpgsign is not enabled in this repo "
+        f"(got {val!r}). Set `git config commit.gpgsign true` or unset "
+        f"signing_required via `config(set={{'signing_required': false}})`."
+    ]
 
 
 @dataclass
@@ -62,6 +87,16 @@ def plan_save(
     """Generate a plan for the 'save' verb (stage + commit)."""
     if config is None:
         config = load_config(state.repo_root)
+
+    # Fail fast if signing is required but commit.gpgsign isn't set.
+    signing_warnings = _signing_required_check(state, "save")
+    if signing_warnings:
+        return Plan(
+            plan_id=plan_id, verb="save", steps=[],
+            state_hash=state.compute_hash(),
+            warnings=signing_warnings,
+            params={"message": message, "include": include, "exclude": exclude, "files": files},
+        )
 
     # Determine which files to stage
     target_files = _resolve_files(state, include, exclude, files)
@@ -165,7 +200,19 @@ def plan_sync(
 
     # Fetch
     steps.append(PlanStep(action="fetch", params={"remote": "origin"}))
-    actual_strategy = strategy or ("merge" if is_default else "rebase")
+    # Strategy precedence: explicit > runtime config > branch-based default.
+    # default_sync_strategy applies to feature branches; default branch
+    # always uses merge (rebasing on a publicly-pushed default branch is
+    # almost always wrong).
+    if strategy is None:
+        from jetsam.config.runtime import get_runtime
+        runtime_strategy = get_runtime().default_sync_strategy
+        if is_default:
+            actual_strategy = "merge"
+        else:
+            actual_strategy = runtime_strategy
+    else:
+        actual_strategy = strategy
 
     if state.upstream:
         if actual_strategy == "rebase":
@@ -231,6 +278,15 @@ def plan_ship(
     """Generate a plan for the 'ship' verb (stage + commit + push + PR)."""
     if config is None:
         config = load_config(state.repo_root)
+
+    signing_warnings = _signing_required_check(state, "ship")
+    if signing_warnings:
+        return Plan(
+            plan_id=plan_id, verb="ship", steps=[],
+            state_hash=state.compute_hash(),
+            warnings=signing_warnings,
+            params={"message": message, "include": include, "exclude": exclude, "files": files},
+        )
 
     # Resolve defaults from config when not explicitly set
     if open_pr is None and merge is None:
@@ -576,6 +632,15 @@ def plan_release(
         notes: Release notes text.
         draft: Create as a draft release.
     """
+    signing_warnings = _signing_required_check(state, "release")
+    if signing_warnings:
+        return Plan(
+            plan_id=plan_id, verb="release", steps=[],
+            state_hash=state.compute_hash(),
+            warnings=signing_warnings,
+            params={"tag": tag, "title": title, "notes": notes, "draft": draft},
+        )
+
     steps: list[PlanStep] = []
     warnings: list[str] = []
     actual_title = title or tag

--- a/tests/test_config_consumption.py
+++ b/tests/test_config_consumption.py
@@ -1,0 +1,126 @@
+"""Tests for workflow verbs consuming runtime config knobs."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from jetsam.config import runtime as rt
+from jetsam.config.runtime import JetsamRuntimeConfig, update_runtime
+from jetsam.core.planner import plan_save, plan_ship, plan_sync, plan_release
+from jetsam.core.state import build_state
+
+
+@pytest.fixture(autouse=True)
+def _isolate_runtime():
+    rt._runtime = JetsamRuntimeConfig()
+    rt._seed = JetsamRuntimeConfig()
+    yield
+    rt._runtime = JetsamRuntimeConfig()
+    rt._seed = JetsamRuntimeConfig()
+
+
+def _init_repo(path: Path, on_branch: str = "feature/x", gpgsign: bool = False) -> None:
+    subprocess.run(["git", "init", "-b", "main"], cwd=path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-c", "commit.gpgsign=false", "-c", "user.email=t@t", "-c", "user.name=t",
+         "commit", "--allow-empty", "-m", "init"],
+        cwd=path, check=True, capture_output=True,
+    )
+    if on_branch != "main":
+        subprocess.run(["git", "checkout", "-b", on_branch], cwd=path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "commit.gpgsign", "true" if gpgsign else "false"],
+        cwd=path, check=True, capture_output=True,
+    )
+
+
+class TestSyncStrategyConsumed:
+    """plan_sync should use runtime.default_sync_strategy as the fallback
+    for feature branches when no explicit strategy is passed."""
+
+    def test_feature_branch_default_is_rebase(self, tmp_path):
+        _init_repo(tmp_path, on_branch="feature/x")
+        state = build_state(cwd=str(tmp_path))
+        plan = plan_sync(state, plan_id="p1", strategy=None)
+        # Even without an upstream, no sync steps run; this test just
+        # verifies the runtime knob does not poison the verb when not set.
+        assert plan.verb == "sync"
+
+    def test_runtime_can_override_to_merge(self, tmp_path):
+        _init_repo(tmp_path, on_branch="feature/x")
+        # Set up an upstream so the strategy actually matters
+        subprocess.run(["git", "remote", "add", "origin", str(tmp_path)], cwd=tmp_path,
+                       check=True, capture_output=True)
+        # Make a fake upstream by pointing the branch at HEAD
+        subprocess.run(["git", "update-ref", "refs/remotes/origin/feature/x", "HEAD"],
+                       cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(["git", "branch", "--set-upstream-to=origin/feature/x"],
+                       cwd=tmp_path, check=True, capture_output=True)
+
+        update_runtime({"default_sync_strategy": "merge"})
+        state = build_state(cwd=str(tmp_path))
+        plan = plan_sync(state, plan_id="p2", strategy=None)
+        # Find the rebase/merge step
+        ops = [s.action for s in plan.steps]
+        assert "merge" in ops, f"expected merge in {ops}"
+        assert "rebase" not in ops, f"unexpected rebase in {ops}"
+
+    def test_explicit_strategy_still_wins(self, tmp_path):
+        _init_repo(tmp_path, on_branch="feature/x")
+        subprocess.run(["git", "remote", "add", "origin", str(tmp_path)], cwd=tmp_path,
+                       check=True, capture_output=True)
+        subprocess.run(["git", "update-ref", "refs/remotes/origin/feature/x", "HEAD"],
+                       cwd=tmp_path, check=True, capture_output=True)
+        subprocess.run(["git", "branch", "--set-upstream-to=origin/feature/x"],
+                       cwd=tmp_path, check=True, capture_output=True)
+
+        update_runtime({"default_sync_strategy": "merge"})
+        state = build_state(cwd=str(tmp_path))
+        plan = plan_sync(state, plan_id="p3", strategy="rebase")
+        ops = [s.action for s in plan.steps]
+        assert "rebase" in ops, f"explicit rebase should win over runtime merge — got {ops}"
+
+
+class TestSigningRequired:
+    """When signing_required=True and commit.gpgsign isn't enabled, the
+    plan should be refused with a clear warning."""
+
+    def test_save_refuses_when_signing_required_but_unset(self, tmp_path):
+        _init_repo(tmp_path, gpgsign=False)
+        update_runtime({"signing_required": True})
+        # Touch a file so there's something to plan
+        (tmp_path / "f.txt").write_text("hi")
+        state = build_state(cwd=str(tmp_path))
+        plan = plan_save(state, plan_id="p4", message="m", files=["f.txt"])
+        assert plan.steps == [], "expected no steps when signing not configured"
+        assert any("signing_required" in w for w in plan.warnings)
+
+    def test_save_proceeds_when_signing_configured(self, tmp_path):
+        _init_repo(tmp_path, gpgsign=True)
+        update_runtime({"signing_required": True})
+        (tmp_path / "f.txt").write_text("hi")
+        state = build_state(cwd=str(tmp_path))
+        plan = plan_save(state, plan_id="p5", message="m", files=["f.txt"])
+        # Should have steps now
+        assert len(plan.steps) > 0
+        assert not any("signing_required" in w for w in plan.warnings)
+
+    def test_save_unaffected_when_signing_not_required(self, tmp_path):
+        _init_repo(tmp_path, gpgsign=False)
+        # signing_required not set (default False)
+        (tmp_path / "f.txt").write_text("hi")
+        state = build_state(cwd=str(tmp_path))
+        plan = plan_save(state, plan_id="p6", message="m", files=["f.txt"])
+        # Should plan normally
+        assert len(plan.steps) > 0
+
+    def test_release_refuses_when_signing_required_but_unset(self, tmp_path):
+        _init_repo(tmp_path, on_branch="main", gpgsign=False)
+        update_runtime({"signing_required": True})
+        state = build_state(cwd=str(tmp_path))
+        plan = plan_release(state, plan_id="p7", tag="v0.0.1")
+        assert plan.steps == []
+        assert any("signing_required" in w for w in plan.warnings)


### PR DESCRIPTION
Wires the runtime config knobs into the verbs that should respect them. sync() consults default_sync_strategy on feature branches; save/ship/release fail fast when signing_required is set but commit.gpgsign isn't enabled. Explicit args still win. 7 new tests, full suite still green (pre-existing test_state failure unrelated).