### PR TITLE
chore(release): stabilize main for 1.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "jetsam-mcp"
-version = "1.1.1"
+version = "1.1.2"
 description = "Git workflow accelerator for humans and agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/jetsam/__init__.py
+++ b/src/jetsam/__init__.py
@@ -1,3 +1,3 @@
 """jetsam — Git workflow accelerator for humans and agents."""
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"

--- a/src/jetsam/config/runtime.py
+++ b/src/jetsam/config/runtime.py
@@ -16,7 +16,6 @@ import os
 from dataclasses import dataclass, field, fields, replace
 from typing import Any
 
-
 _ENV_PREFIX = "JETSAM_"
 
 _VALID_LOG_LEVELS = {"debug", "info", "warn", "warning", "error"}
@@ -54,7 +53,7 @@ class JetsamRuntimeConfig:
     auto_confirm_safe_verbs: list[str] = field(default_factory=list)
 
     @classmethod
-    def from_env(cls, env: dict[str, str] | None = None) -> "JetsamRuntimeConfig":
+    def from_env(cls, env: dict[str, str] | None = None) -> JetsamRuntimeConfig:
         """Build a config seeded from environment variables.
 
         Variables read (each optional):
@@ -72,12 +71,12 @@ class JetsamRuntimeConfig:
 
         if v := e.get(f"{_ENV_PREFIX}ACTIVE_ROOT"):
             cfg.active_root = v
-        if v := e.get(f"{_ENV_PREFIX}LOG_LEVEL"):
-            if v.lower() in _VALID_LOG_LEVELS:
-                cfg.log_level = v.lower()
-        if v := e.get(f"{_ENV_PREFIX}DEFAULT_SYNC_STRATEGY"):
-            if v.lower() in _VALID_SYNC_STRATEGIES:
-                cfg.default_sync_strategy = v.lower()
+        v = e.get(f"{_ENV_PREFIX}LOG_LEVEL")
+        if v and v.lower() in _VALID_LOG_LEVELS:
+            cfg.log_level = v.lower()
+        v = e.get(f"{_ENV_PREFIX}DEFAULT_SYNC_STRATEGY")
+        if v and v.lower() in _VALID_SYNC_STRATEGIES:
+            cfg.default_sync_strategy = v.lower()
         if v := e.get(f"{_ENV_PREFIX}DEFAULT_BASE_BRANCH"):
             cfg.default_base_branch = v
         if v := e.get(f"{_ENV_PREFIX}SIGNING_REQUIRED"):
@@ -148,7 +147,8 @@ def _validate_one(key: str, value: Any) -> None:
     elif key == "default_sync_strategy":
         if not isinstance(value, str) or value.lower() not in _VALID_SYNC_STRATEGIES:
             raise ValueError(
-                f"default_sync_strategy must be one of {sorted(_VALID_SYNC_STRATEGIES)}, got {value!r}"
+                f"default_sync_strategy must be one of "
+                f"{sorted(_VALID_SYNC_STRATEGIES)}, got {value!r}"
             )
     elif key == "signing_required":
         if not isinstance(value, bool):
@@ -157,5 +157,6 @@ def _validate_one(key: str, value: Any) -> None:
         if not isinstance(value, list) or not all(isinstance(s, str) for s in value):
             raise ValueError(f"auto_confirm_safe_verbs must be list[str], got {value!r}")
     elif key in ("active_root", "default_base_branch"):
-        if value is not None and not isinstance(value, str):
-            raise ValueError(f"{key} must be str or None, got {type(value).__name__}")
+        if value is None or isinstance(value, str):
+            return
+        raise ValueError(f"{key} must be str or None, got {type(value).__name__}")

--- a/src/jetsam/core/planner.py
+++ b/src/jetsam/core/planner.py
@@ -207,10 +207,7 @@ def plan_sync(
     if strategy is None:
         from jetsam.config.runtime import get_runtime
         runtime_strategy = get_runtime().default_sync_strategy
-        if is_default:
-            actual_strategy = "merge"
-        else:
-            actual_strategy = runtime_strategy
+        actual_strategy = "merge" if is_default else runtime_strategy
     else:
         actual_strategy = strategy
 

--- a/tests/test_config_consumption.py
+++ b/tests/test_config_consumption.py
@@ -9,7 +9,7 @@ import pytest
 
 from jetsam.config import runtime as rt
 from jetsam.config.runtime import JetsamRuntimeConfig, update_runtime
-from jetsam.core.planner import plan_save, plan_ship, plan_sync, plan_release
+from jetsam.core.planner import plan_release, plan_save, plan_sync
 from jetsam.core.state import build_state
 
 
@@ -30,7 +30,9 @@ def _init_repo(path: Path, on_branch: str = "feature/x", gpgsign: bool = False) 
         cwd=path, check=True, capture_output=True,
     )
     if on_branch != "main":
-        subprocess.run(["git", "checkout", "-b", on_branch], cwd=path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "checkout", "-b", on_branch], cwd=path, check=True, capture_output=True
+        )
     subprocess.run(
         ["git", "config", "commit.gpgsign", "true" if gpgsign else "false"],
         cwd=path, check=True, capture_output=True,

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -169,6 +169,7 @@ class TestConfigToolViaMCP:
     @pytest.fixture(scope="class")
     def mcp(self):
         from mcp.server.fastmcp import FastMCP
+
         from jetsam.mcp.tools import register_tools
         server = FastMCP("test")
         register_tools(server)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -34,8 +34,10 @@ class TestBuildState:
         state1 = build_state(cwd=str(tmp_git_repo))
         hash1 = state1.compute_hash()
 
-        # Create a new file
-        (tmp_git_repo / "new.py").write_text("new\n")
+        # Modify a TRACKED file — an unstaged change must change the hash.
+        # (A new *untracked* file deliberately does not; see
+        # test_unscoped_hash_stable_across_untracked_churn_e2e.)
+        (tmp_git_repo / "README.md").write_text("# Test\nmodified\n")
 
         state2 = build_state(cwd=str(tmp_git_repo))
         hash2 = state2.compute_hash()
@@ -100,6 +102,46 @@ class TestBuildState:
         plans.mkdir(parents=True)
         (plans / "p_abc.json").write_text('{"plan": 1}\n')
 
+        hash_after = build_state(cwd=str(tmp_git_repo)).compute_hash()
+        assert hash_before == hash_after
+
+    def test_unscoped_hash_ignores_untracked_churn(self):
+        """Untracked-file churn (agent-runtime dirs like .kibitzer/, .bird/) must
+        not change the unscoped hash — generalizes the #12 .jetsam/ fix so such
+        dirs don't cause stale_plan on start/sync."""
+        base = dict(
+            branch="feature", upstream="origin/feature", default_branch="main",
+            dirty=True, staged=[], unstaged=[], untracked=[".kibitzer/a"],
+            ahead=0, behind=0, stash_count=0,
+            platform="github", remote="user/repo",
+            remote_url="git@github.com:user/repo.git",
+            head_sha="abc123", repo_root="/tmp/repo",
+        )
+        s1 = RepoState(**base)
+        s2 = RepoState(**{**base, "untracked": [".kibitzer/a", ".bird/log", "scratch.txt"]})
+        assert s1.compute_hash() == s2.compute_hash()
+
+    def test_unscoped_hash_reflects_tracked_changes(self):
+        """Sanity: excluding untracked must not also drop tracked changes."""
+        base = dict(
+            branch="feature", upstream="origin/feature", default_branch="main",
+            dirty=False, staged=[], unstaged=[], untracked=[],
+            ahead=0, behind=0, stash_count=0,
+            platform="github", remote="user/repo",
+            remote_url="git@github.com:user/repo.git",
+            head_sha="abc123", repo_root="/tmp/repo",
+        )
+        s1 = RepoState(**base)
+        s2 = RepoState(**{**base, "staged": ["src/x.py"]})
+        assert s1.compute_hash() != s2.compute_hash()
+
+    def test_unscoped_hash_stable_across_untracked_churn_e2e(self, tmp_git_repo: Path):
+        """End-to-end: creating an arbitrary untracked dir must not change the
+        unscoped hash (the stale_plan-on-confirm bug for non-.jetsam dirs)."""
+        hash_before = build_state(cwd=str(tmp_git_repo)).compute_hash()
+        kb = tmp_git_repo / ".kibitzer"
+        kb.mkdir()
+        (kb / "session.json").write_text('{"a": 1}\n')
         hash_after = build_state(cwd=str(tmp_git_repo)).compute_hash()
         assert hash_before == hash_after
 


### PR DESCRIPTION
main went red after the recent config merges (#13/#15). This makes it green so the **1.1.2** release can publish. No behavior changes.

## Fixes
- **`tests/test_state.py`** — the untracked-exclusion hash change (the stale-plan fix, generalizing #12) had already landed on main, but `test_state_hash_changes_on_modification` still asserted the *old* "new untracked file changes the hash" behavior, so it failed. Updated it to assert on a **tracked** modification, and added regression tests for the untracked-churn behavior (incl. an e2e creating an arbitrary untracked dir).
- **Lint** (`ruff check src/ tests/` now clean): `config/runtime.py` SIM102 (walrus→assignment, `active_root` early-return) + E501 wrap; `core/planner.py` SIM108 ternary; `test_config_consumption.py` E501 + F401; import sorting.

## Verification
`ruff` ✓, `mypy --strict` ✓ (no issues, 45 files), **402 tests pass**. Bumps 1.1.1 → 1.1.2.

Note: the stale-plan fix itself is already on main (it was entangled into `cdd243a` via a shared working tree); this PR supplies the missing test update + lint cleanup + version bump so `v1.1.2` can ship. Supersedes the now-redundant #14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)