### PR TITLE
Scope commits to the plan's pathspec; remove dead auto_confirm_safe_verbs (#19)

### DIFF
--- a/src/jetsam/config/runtime.py
+++ b/src/jetsam/config/runtime.py
@@ -13,7 +13,7 @@ hardcoded defaults.
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass, field, fields, replace
+from dataclasses import dataclass, fields, replace
 from typing import Any
 
 _ENV_PREFIX = "JETSAM_"
@@ -39,10 +39,6 @@ class JetsamRuntimeConfig:
         signing_required: if True, save/ship/release fail fast when GPG isn't
             configured for the repo. Useful in fleet repos that require
             signed commits.
-        auto_confirm_safe_verbs: list of verb names that bypass the
-            plan→confirm flow. Default empty. Add "save" here to skip the
-            confirm step for low-risk commits. NOT recommended for sync /
-            ship / release / finish (those touch remote state).
     """
 
     active_root: str | None = None
@@ -50,7 +46,6 @@ class JetsamRuntimeConfig:
     default_sync_strategy: str = "rebase"
     default_base_branch: str | None = None
     signing_required: bool = False
-    auto_confirm_safe_verbs: list[str] = field(default_factory=list)
 
     @classmethod
     def from_env(cls, env: dict[str, str] | None = None) -> JetsamRuntimeConfig:
@@ -62,7 +57,6 @@ class JetsamRuntimeConfig:
             JETSAM_DEFAULT_SYNC_STRATEGY — rebase/merge
             JETSAM_DEFAULT_BASE_BRANCH — branch name
             JETSAM_SIGNING_REQUIRED    — true/false/1/0/yes/no
-            JETSAM_AUTO_CONFIRM_SAFE_VERBS — comma-separated, e.g. "save,switch"
 
         Invalid values fall back to the dataclass default.
         """
@@ -81,8 +75,6 @@ class JetsamRuntimeConfig:
             cfg.default_base_branch = v
         if v := e.get(f"{_ENV_PREFIX}SIGNING_REQUIRED"):
             cfg.signing_required = _parse_bool(v)
-        if v := e.get(f"{_ENV_PREFIX}AUTO_CONFIRM_SAFE_VERBS"):
-            cfg.auto_confirm_safe_verbs = [s.strip() for s in v.split(",") if s.strip()]
 
         return cfg
 
@@ -153,9 +145,6 @@ def _validate_one(key: str, value: Any) -> None:
     elif key == "signing_required":
         if not isinstance(value, bool):
             raise ValueError(f"signing_required must be bool, got {type(value).__name__}")
-    elif key == "auto_confirm_safe_verbs":
-        if not isinstance(value, list) or not all(isinstance(s, str) for s in value):
-            raise ValueError(f"auto_confirm_safe_verbs must be list[str], got {value!r}")
     elif key in ("active_root", "default_base_branch"):
         if value is None or isinstance(value, str):
             return

--- a/src/jetsam/core/executor.py
+++ b/src/jetsam/core/executor.py
@@ -182,7 +182,16 @@ def _exec_stage(step: PlanStep, cwd: str | None) -> StepResult:
 
 def _exec_commit(step: PlanStep, cwd: str | None) -> StepResult:
     message = step.params.get("message", "update")
-    result = run_git_sync(["commit", "-m", message], cwd=cwd)
+    # Commit an explicit pathspec (the plan's file list) rather than the whole
+    # index, so an unrelated already-staged file — or one removed via
+    # modify_plan(exclude=...) — is not swept into the commit (issue #19).
+    # Fall back to a bare commit only when a plan carries no file list (older
+    # plans / steps that don't set one).
+    files = step.params.get("files")
+    if files:
+        result = run_git_sync(["commit", "-m", message, "--", *files], cwd=cwd)
+    else:
+        result = run_git_sync(["commit", "-m", message], cwd=cwd)
     if result.ok:
         # Extract SHA from output
         sha_result = run_git_sync(["rev-parse", "--short", "HEAD"], cwd=cwd)

--- a/src/jetsam/core/planner.py
+++ b/src/jetsam/core/planner.py
@@ -131,7 +131,13 @@ def plan_save(
     steps.append(
         PlanStep(
             action="commit",
-            params={"message": message, "file_count": len(all_staged)},
+            params={
+                "message": message,
+                "file_count": len(all_staged),
+                # Explicit pathspec so the commit is scoped to the plan's files
+                # (issue #19); see _exec_commit.
+                "files": all_staged,
+            },
         )
     )
 
@@ -329,7 +335,13 @@ def plan_ship(
         steps.append(
             PlanStep(
                 action="commit",
-                params={"message": message, "file_count": len(all_staged)},
+                params={
+                    "message": message,
+                    "file_count": len(all_staged),
+                    # Explicit pathspec so the commit is scoped to the plan's
+                    # files (issue #19); see _exec_commit.
+                    "files": all_staged,
+                },
             )
         )
     elif not message:

--- a/src/jetsam/core/plans.py
+++ b/src/jetsam/core/plans.py
@@ -164,19 +164,24 @@ def update_plan(
                 step.params["title"] = message
 
     if exclude is not None:
-        # Remove files matching the exclude pattern from stage steps
+        # Remove files matching the exclude pattern from both the stage step and
+        # the commit step's pathspec. Filtering the commit list too is essential:
+        # the executor commits that explicit pathspec, so leaving an excluded
+        # file in it would silently re-include it (issue #19).
+        removed_all: list[str] = []
         for step in plan.steps:
-            if step.action == "stage":
+            if step.action in ("stage", "commit"):
                 old_files = step.params.get("files", [])
                 new_files = [f for f in old_files if not fnmatch.fnmatch(f, exclude)]
                 removed = [f for f in old_files if f not in new_files]
                 if removed:
                     step.params["files"] = new_files
-                    diff["removed_files"] = removed
-                    # Update file count in commit step
-                    for cs in plan.steps:
-                        if cs.action == "commit":
-                            cs.params["file_count"] = len(new_files)
+                    removed_all.extend(removed)
+                    if step.action == "commit":
+                        step.params["file_count"] = len(new_files)
+        if removed_all:
+            # De-duplicate while preserving order (a file can appear in both steps).
+            diff["removed_files"] = list(dict.fromkeys(removed_all))
 
     if include is not None or files is not None:
         # Add files — this requires the full file list from state

--- a/src/jetsam/mcp/tools.py
+++ b/src/jetsam/mcp/tools.py
@@ -698,12 +698,10 @@ def register_tools(mcp: FastMCP) -> None:
             default_sync_strategy — rebase | merge
             default_base_branch — override for "main"
             signing_required    — fail fast if GPG not configured
-            auto_confirm_safe_verbs — verbs that bypass plan→confirm
 
         Env vars (seed at launch only): JETSAM_ACTIVE_ROOT,
         JETSAM_LOG_LEVEL, JETSAM_DEFAULT_SYNC_STRATEGY,
-        JETSAM_DEFAULT_BASE_BRANCH, JETSAM_SIGNING_REQUIRED,
-        JETSAM_AUTO_CONFIRM_SAFE_VERBS.
+        JETSAM_DEFAULT_BASE_BRANCH, JETSAM_SIGNING_REQUIRED.
 
         Args:
             set: Dict of keys to update. Unknown keys raise; invalid

--- a/tests/test_commit_pathspec.py
+++ b/tests/test_commit_pathspec.py
@@ -1,0 +1,107 @@
+"""Regression tests for issue #19.
+
+`_exec_commit` committed with `git commit -m <msg>` and no pathspec, so it
+committed the *entire* index rather than the plan's file list. Because
+`modify_plan(exclude=...)` only filters the *stage* step, an excluded (or
+otherwise unrelated already-staged) file still landed in the commit — a false
+assurance. The commit step now carries an explicit file list and commits only
+that pathspec; `modify_plan(exclude=...)` filters it too.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from jetsam.core.executor import _exec_commit
+from jetsam.core.planner import Plan, PlanStep, plan_save
+from jetsam.core.plans import update_plan
+from jetsam.core.state import build_state
+
+_ENV = {
+    **os.environ,
+    "GIT_AUTHOR_NAME": "Test",
+    "GIT_AUTHOR_EMAIL": "test@test.com",
+    "GIT_COMMITTER_NAME": "Test",
+    "GIT_COMMITTER_EMAIL": "test@test.com",
+}
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=repo, env=_ENV, capture_output=True, text=True, check=True
+    ).stdout
+
+
+def _committed_files(repo: Path) -> set[str]:
+    out = _git(repo, "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD")
+    return {line for line in out.splitlines() if line}
+
+
+def _staged_files(repo: Path) -> set[str]:
+    out = _git(repo, "diff", "--cached", "--name-only")
+    return {line for line in out.splitlines() if line}
+
+
+def test_exec_commit_commits_only_pathspec_not_whole_index(tmp_git_repo: Path) -> None:
+    """A commit step with an explicit file list must not sweep in an unrelated
+    already-staged file."""
+    repo = tmp_git_repo
+
+    # Two tracked files, both modified and staged (a dirty index with an
+    # unrelated staged change alongside the plan's own file).
+    (repo / "wanted.py").write_text("wanted = 1\n")
+    (repo / "unrelated.py").write_text("unrelated = 1\n")
+    _git(repo, "add", "wanted.py", "unrelated.py")
+
+    step = PlanStep(action="commit", params={"message": "only wanted", "files": ["wanted.py"]})
+    result = _exec_commit(step, cwd=str(repo))
+    assert result.ok, result.error
+
+    committed = _committed_files(repo)
+    assert "wanted.py" in committed
+    assert "unrelated.py" not in committed, "commit swept in an unrelated staged file"
+    # The unrelated change is left untouched in the index.
+    assert "unrelated.py" in _staged_files(repo)
+
+
+def test_plan_save_populates_commit_file_list(tmp_git_repo: Path) -> None:
+    """plan_save must give the commit step an explicit file list (the pathspec)."""
+    repo = tmp_git_repo
+    (repo / "a.py").write_text("a = 1\n")
+    (repo / "b.py").write_text("b = 1\n")
+
+    state = build_state(cwd=str(repo))
+    plan = plan_save(state, plan_id="p_deadbeef", message="add", files=["a.py", "b.py"])
+    commit = next(s for s in plan.steps if s.action == "commit")
+    assert set(commit.params.get("files", [])) == {"a.py", "b.py"}
+
+
+def test_modify_plan_exclude_filters_commit_pathspec() -> None:
+    """modify_plan(exclude=...) must filter the commit file list, not only stage."""
+    plan = Plan(
+        plan_id="p_deadbeef",
+        verb="save",
+        steps=[
+            PlanStep(action="stage", params={"files": ["a.py", "b_generated.py"]}),
+            PlanStep(
+                action="commit",
+                params={"message": "m", "file_count": 2, "files": ["a.py", "b_generated.py"]},
+            ),
+        ],
+        state_hash="x",
+        repo_root="/tmp/repo",
+    )
+
+    update_plan(plan, exclude="*generated*")
+
+    commit = next(s for s in plan.steps if s.action == "commit")
+    assert commit.params["files"] == ["a.py"], "exclude did not filter the commit pathspec"
+
+
+def test_runtime_config_has_no_dead_auto_confirm_field() -> None:
+    """The unused auto_confirm_safe_verbs config knob is removed."""
+    from jetsam.config.runtime import JetsamRuntimeConfig
+
+    assert not hasattr(JetsamRuntimeConfig(), "auto_confirm_safe_verbs")

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -30,7 +30,6 @@ class TestFromEnv:
         assert cfg.log_level == "info"
         assert cfg.default_sync_strategy == "rebase"
         assert cfg.signing_required is False
-        assert cfg.auto_confirm_safe_verbs == []
 
     def test_active_root_from_env(self):
         cfg = JetsamRuntimeConfig.from_env(env={"JETSAM_ACTIVE_ROOT": "/tmp/repo"})
@@ -53,12 +52,6 @@ class TestFromEnv:
         for v in ("false", "0", "no", "off", ""):
             cfg = JetsamRuntimeConfig.from_env(env={"JETSAM_SIGNING_REQUIRED": v})
             assert cfg.signing_required is False, f"failed for {v!r}"
-
-    def test_safe_verbs_csv(self):
-        cfg = JetsamRuntimeConfig.from_env(
-            env={"JETSAM_AUTO_CONFIRM_SAFE_VERBS": "save, switch ,start"}
-        )
-        assert cfg.auto_confirm_safe_verbs == ["save", "switch", "start"]
 
 
 class TestUpdateRuntime:
@@ -89,9 +82,11 @@ class TestUpdateRuntime:
         with pytest.raises(ValueError, match="signing_required"):
             update_runtime({"signing_required": "true"})  # string, not bool
 
-    def test_safe_verbs_must_be_list_of_str(self):
-        with pytest.raises(ValueError, match="auto_confirm_safe_verbs"):
-            update_runtime({"auto_confirm_safe_verbs": "save,switch"})
+    def test_removed_auto_confirm_key_is_rejected_as_unknown(self):
+        # The dead auto_confirm_safe_verbs knob was removed; setting it now
+        # fails as an unknown key rather than being silently accepted.
+        with pytest.raises(ValueError, match="unknown config key"):
+            update_runtime({"auto_confirm_safe_verbs": ["save"]})
 
 
 class TestResetRuntime:


### PR DESCRIPTION
Addresses the correctness items in #19.

## Commit pathspec

`_exec_commit` ran `git commit -m <msg>` with **no pathspec**, so it committed the entire index rather than the plan's file list. Because `modify_plan(exclude=…)` only filtered the *stage* step, a file that was excluded — or an unrelated file already staged in the index — still landed in the commit, giving a false sense that the exclusion took effect.

- The commit step now carries an explicit `files` list (the plan's staged set), and `_exec_commit` runs `git commit -m <msg> -- <files>`, scoping the commit to exactly those paths. It falls back to a bare commit only when a plan carries no file list (defensive; the save/ship planners always set one now).
- `modify_plan(exclude=…)` now filters the **commit** step's pathspec too, not just the stage step.

Semantics note: `git commit -- <paths>` uses `--only` semantics (working-tree contents of the named paths; other staged paths are left untouched), which is the intended scoping. State drift between plan and execution is already caught by the existing `state_hash` guard.

## Dead config removal

`auto_confirm_safe_verbs` was parsed from env, stored, validated, and documented, but **never read** by any decision path. Wiring it up would have introduced an auto-confirm bypass of the `plan→confirm` gate, so removal is the correct resolution for a hardening-adjacent cleanup rather than activation. Removed from the dataclass, `from_env`, `_validate_one`, and the `config()`/env docstrings; setting the key now fails as an unknown config key.

## Tests

`tests/test_commit_pathspec.py`:
- `_exec_commit` with an explicit file list commits only that pathspec and leaves an unrelated staged file uncommitted (red before the change).
- `plan_save` populates the commit step's file list.
- `modify_plan(exclude=…)` filters the commit pathspec.
- The removed config field is gone.

Full suite: 445 passed. `ruff` and `mypy` clean. Confirmed red→green (4 new assertions fail before, pass after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjVKQED5RRjQzArQZA8X4n