### PR TITLE
fix: tolerate unknown fields when building API-response models

### DIFF
--- a/src/jetsam/platforms/base.py
+++ b/src/jetsam/platforms/base.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field, fields
-from typing import Any
+from typing import Any, TypeVar
+
+_T = TypeVar("_T", bound="FieldTolerant")
 
 
 class FieldTolerant:
@@ -22,7 +24,7 @@ class FieldTolerant:
     """
 
     @classmethod
-    def from_fields(cls, **kwargs: Any):
+    def from_fields(cls: type[_T], **kwargs: Any) -> _T:
         declared = {f.name for f in fields(cls)}  # type: ignore[arg-type]
         return cls(**{k: v for k, v in kwargs.items() if k in declared})
 

--- a/src/jetsam/platforms/base.py
+++ b/src/jetsam/platforms/base.py
@@ -3,11 +3,32 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
+from typing import Any
+
+
+class FieldTolerant:
+    """Mixin: construct a dataclass while silently dropping unknown kwargs.
+
+    Platform adapters build these models from external API responses (gh/glab
+    JSON), and those APIs grow fields over time. A long-running server can
+    also end up with an adapter module newer than the model module (or vice
+    versa) across an editable-install upgrade, in which case the adapter may
+    pass a field the loaded model doesn't declare — historically this crashed
+    with ``PRDetails.__init__() got an unexpected keyword argument``.
+
+    ``from_fields()`` filters kwargs to the fields the class actually
+    declares, so an unknown/new field is ignored instead of raising.
+    """
+
+    @classmethod
+    def from_fields(cls, **kwargs: Any):
+        declared = {f.name for f in fields(cls)}  # type: ignore[arg-type]
+        return cls(**{k: v for k, v in kwargs.items() if k in declared})
 
 
 @dataclass
-class PRDetails:
+class PRDetails(FieldTolerant):
     """Pull request / merge request details."""
 
     number: int
@@ -26,7 +47,7 @@ class PRDetails:
 
 
 @dataclass
-class CheckResult:
+class CheckResult(FieldTolerant):
     """CI check result."""
 
     name: str
@@ -35,7 +56,7 @@ class CheckResult:
 
 
 @dataclass
-class IssueDetails:
+class IssueDetails(FieldTolerant):
     """Issue details."""
 
     number: int

--- a/src/jetsam/platforms/github.py
+++ b/src/jetsam/platforms/github.py
@@ -122,7 +122,7 @@ class GitHubPlatform(Platform):
         results: list[CheckResult] = []
         if isinstance(data, list):
             for item in data:
-                results.append(CheckResult(
+                results.append(CheckResult.from_fields(
                     name=item.get("name", ""),
                     status=_normalize_check_status(item.get("state", "")),
                     url=item.get("detailsUrl", ""),
@@ -289,7 +289,7 @@ def _parse_issue(data: dict[str, Any]) -> IssueDetails:
             a.get("login", "") if isinstance(a, dict) else str(a) for a in raw_assignees
         ]
 
-    return IssueDetails(
+    return IssueDetails.from_fields(
         number=data.get("number", 0),
         title=data.get("title", ""),
         state=data.get("state", "open").lower(),
@@ -312,7 +312,10 @@ def _parse_pr(data: dict[str, Any]) -> PRDetails:
     # tri-state so callers can tell "conflicting" from "not computed yet".
     raw_mergeable = str(data.get("mergeable") or "").lower()
 
-    return PRDetails(
+    # from_fields drops any field the loaded PRDetails doesn't declare, so a
+    # newer parser never crashes an older (already-imported) model — see
+    # FieldTolerant in base.py.
+    return PRDetails.from_fields(
         number=data.get("number", 0),
         state=data.get("state", "open").lower(),
         title=data.get("title", ""),

--- a/src/jetsam/platforms/gitlab.py
+++ b/src/jetsam/platforms/gitlab.py
@@ -125,7 +125,7 @@ class GitLabPlatform(Platform):
             return []
 
         status = _normalize_pipeline_status(pipeline.get("status", ""))
-        return [CheckResult(
+        return [CheckResult.from_fields(
             name="pipeline",
             status=status,
             url=pipeline.get("web_url", ""),
@@ -241,7 +241,9 @@ def _parse_mr(data: dict[str, Any]) -> PRDetails:
     if state == "opened":
         state = "open"
 
-    return PRDetails(
+    # from_fields drops fields the loaded PRDetails doesn't declare — see
+    # FieldTolerant in base.py.
+    return PRDetails.from_fields(
         number=number,
         state=state,
         title=data.get("title", ""),
@@ -271,7 +273,7 @@ def _parse_gl_issue(data: dict[str, Any]) -> IssueDetails:
     if state == "opened":
         state = "open"
 
-    return IssueDetails(
+    return IssueDetails.from_fields(
         number=data.get("iid", data.get("number", 0)),
         title=data.get("title", ""),
         state=state,

--- a/tests/test_platform_github.py
+++ b/tests/test_platform_github.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
+from jetsam.platforms.base import CheckResult, IssueDetails, PRDetails
 from jetsam.platforms.github import (
     GitHubPlatform,
     PlatformError,
@@ -60,6 +61,59 @@ class TestParsepr:
         pr = _parse_pr({"number": 1, "state": "open"})
         assert pr.mergeable is False
         assert pr.mergeable_state == "unknown"
+
+    def test_extra_api_fields_ignored(self):
+        # gh may return fields we don't request/declare; they must not crash
+        pr = _parse_pr({
+            "number": 1,
+            "state": "open",
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN",
+            "someFutureField": {"nested": True},
+        })
+        assert pr.number == 1
+        assert pr.mergeable is True
+
+
+class TestFieldTolerance:
+    """Unknown/new fields must never crash model construction.
+
+    Regression for: PRDetails.__init__() got an unexpected keyword argument
+    'mergeable_state' — raised when a newer adapter passed a field a loaded
+    older model didn't declare. from_fields() drops unknown kwargs.
+    """
+
+    def test_prdetails_tolerates_unknown_fields(self):
+        pr = PRDetails.from_fields(
+            number=7,
+            state="open",
+            title="t",
+            mergeable_state="mergeable",
+            made_up_future_field="surprise",
+        )
+        assert pr.number == 7
+        assert pr.mergeable_state == "mergeable"
+        assert not hasattr(pr, "made_up_future_field")
+
+    def test_prdetails_from_api_dict_with_extras(self):
+        data = {"number": 3, "state": "open", "title": "x",
+                "mergeable_state": "conflicting", "brand_new_field": 123}
+        pr = PRDetails.from_fields(**data)
+        assert pr.number == 3
+        assert pr.mergeable_state == "conflicting"
+
+    def test_issuedetails_tolerates_unknown_fields(self):
+        issue = IssueDetails.from_fields(
+            number=9, title="i", state="open", reaction_summary={"+1": 2},
+        )
+        assert issue.number == 9
+
+    def test_checkresult_tolerates_unknown_fields(self):
+        check = CheckResult.from_fields(
+            name="ci", status="pass", started_at="2026-01-01T00:00:00Z",
+        )
+        assert check.name == "ci"
+        assert check.status == "pass"
 
 
 class TestNormalizeCheckStatus:


### PR DESCRIPTION
## Problem

`pr_view`/`finish` crashed with:

```
PRDetails.__init__() got an unexpected keyword argument 'mergeable_state'
```

Root cause: a long-running jetsam MCP server (editable install) had an older `platforms/base.py` already imported when the on-disk source was updated (5d11ea2 added `mergeable_state`). The platform module is imported lazily at tool-call time, so the server loaded the *new* `github.py` parser — which passed `mergeable_state` — into the *old* in-memory `PRDetails` that didn't declare it. The same crash class recurs any time a parser starts passing a field the loaded dataclass lacks.

Because `pr_view` crashed, `finish` (on the old in-memory code, pre-5d11ea2) planned worktree-removal + branch-delete without a merge step — the merge-planning bug itself was already fixed in 5d11ea2 and is covered by tests (`test_planner.py::test_finish_*`).

## Fix

Add a `FieldTolerant` mixin to `PRDetails`, `IssueDetails`, and `CheckResult`: `from_fields()` filters kwargs to declared dataclass fields, so unknown/new fields are silently dropped instead of raising. All gh/glab parse paths (`_parse_pr`, `_parse_issue`, `_parse_mr`, `_parse_gl_issue`, check-result construction) now go through `from_fields()`.

Once this version is loaded, a future parser passing a field an older loaded model doesn't declare degrades gracefully (field ignored) instead of crashing the tool.

## Tests

- `TestFieldTolerance`: `PRDetails`/`IssueDetails`/`CheckResult` constructed with `mergeable_state` + made-up future fields do not raise.
- `TestParsepr::test_extra_api_fields_ignored`: `_parse_pr` on a dict with undeclared gh keys does not raise.
- Full suite: 447 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjVKQED5RRjQzArQZA8X4n